### PR TITLE
feat: add describe, shortlog, format-patch, archive, ls-remote, ls-tree, submodule

### DIFF
--- a/lib/git.ex
+++ b/lib/git.ex
@@ -811,6 +811,55 @@ defmodule Git do
   end
 
   @doc """
+  Runs `git submodule` to manage submodules.
+
+  ## Options
+
+    * `:config` - a `Git.Config` struct (default: `Git.Config.new()`)
+    * `:status` - show submodule status (default `true`)
+    * `:init` - initialize submodules
+    * `:update` - update submodules
+    * `:add_url` - URL to add as submodule
+    * `:add_path` - path for new submodule
+    * `:deinit` - path to deinit
+    * `:sync` - sync URLs
+    * `:summary` - show summary of changes
+    * `:set_branch` - set branch for submodule (requires `:path`)
+    * `:set_url` - set URL for submodule (requires `:path`)
+    * `:path` - submodule path for set-branch/set-url/init/update
+    * `:recursive` - apply recursively (`--recursive`)
+    * `:force` - force operation (`--force`)
+    * `:remote` - use remote tracking branch (`--remote`)
+    * `:merge` - merge into working tree (`--merge`)
+    * `:rebase` - rebase onto new commits (`--rebase`)
+    * `:depth` - shallow clone depth (`--depth`)
+    * `:reference` - reference repository (`--reference`)
+    * `:name` - logical name for add (`--name`)
+    * `:branch` - branch for add (`-b`)
+    * `:quiet` - suppress output (`-q`)
+    * `:all` - all submodules for deinit (`--all`)
+
+  The `foreach` subcommand is not supported because it requires an arbitrary
+  shell command, which does not fit the structured command model.
+
+  ## Examples
+
+      Git.submodule()
+      Git.submodule(add_url: "https://example.com/lib.git", add_path: "vendor/lib")
+      Git.submodule(init: true)
+      Git.submodule(update: true, recursive: true)
+      Git.submodule(deinit: "vendor/lib", force: true)
+
+  """
+  @spec submodule(keyword()) ::
+          {:ok, [Git.SubmoduleEntry.t()]} | {:ok, :done} | {:ok, String.t()} | {:error, term()}
+  def submodule(opts \\ []) do
+    {config, rest} = Keyword.pop(opts, :config, Config.new())
+    command = struct!(Git.Commands.Submodule, rest)
+    Git.Command.run(Git.Commands.Submodule, command, config)
+  end
+
+  @doc """
   Runs `git config` to read or write git configuration values.
 
   ## Options
@@ -981,5 +1030,203 @@ defmodule Git do
     {config, rest} = Keyword.pop(opts, :config, Config.new())
     command = struct!(Git.Commands.Grep, [{:pattern, pattern} | rest])
     Git.Command.run(Git.Commands.Grep, command, config)
+  end
+
+  @doc """
+  Runs `git describe` to find the most recent tag reachable from a commit.
+
+  ## Options
+
+    * `:config` - a `Git.Config` struct (default: `Git.Config.new()`)
+    * `:ref` - commit to describe (default: `nil`, describes HEAD)
+    * `:tags` - use any tag, not just annotated (`--tags`)
+    * `:all` - use any ref (`--all`)
+    * `:long` - always use long format (`--long`)
+    * `:first_parent` - follow only first parent (`--first-parent`)
+    * `:abbrev` - abbreviation length (`--abbrev=N`)
+    * `:exact_match` - only output exact matches (`--exact-match`)
+    * `:dirty` - describe with dirty suffix (`--dirty` or `--dirty=MARK`)
+    * `:always` - show abbreviated commit if no tag found (`--always`)
+    * `:match` - only consider tags matching glob (`--match=`)
+    * `:exclude` - exclude tags matching glob (`--exclude=`)
+    * `:candidates` - number of candidate tags to consider (`--candidates=N`)
+    * `:broken` - describe broken working tree as broken (`--broken`)
+
+  ## Examples
+
+      Git.describe(tags: true)
+      Git.describe(always: true, abbrev: 7)
+      Git.describe(exact_match: true, ref: "v1.0")
+
+  """
+  @spec describe(keyword()) :: {:ok, String.t()} | {:error, term()}
+  def describe(opts \\ []) do
+    {config, rest} = Keyword.pop(opts, :config, Config.new())
+    command = struct!(Git.Commands.Describe, rest)
+    Git.Command.run(Git.Commands.Describe, command, config)
+  end
+
+  @doc """
+  Runs `git shortlog` to summarize log output by author.
+
+  ## Options
+
+    * `:config` - a `Git.Config` struct (default: `Git.Config.new()`)
+    * `:numbered` - sort by number of commits (`-n`)
+    * `:summary` - suppress commit descriptions, show count only (`-s`)
+    * `:email` - show email addresses (`-e`)
+    * `:group` - group by field (`--group=`, e.g. `"author"`, `"committer"`)
+    * `:ref` - ref range (e.g. `"v1.0..HEAD"`)
+    * `:max_count` - limit number of commits (`--max-count=N`)
+    * `:since` - show commits after date (`--since=`)
+    * `:until_date` - show commits before date (`--until=`)
+    * `:all` - all branches (`--all`)
+
+  ## Examples
+
+      Git.shortlog(summary: true, numbered: true)
+      Git.shortlog(email: true, ref: "v1.0..HEAD")
+
+  """
+  @spec shortlog(keyword()) :: {:ok, [Git.ShortlogEntry.t()]} | {:error, term()}
+  def shortlog(opts \\ []) do
+    {config, rest} = Keyword.pop(opts, :config, Config.new())
+    command = struct!(Git.Commands.Shortlog, rest)
+    Git.Command.run(Git.Commands.Shortlog, command, config)
+  end
+
+  @doc """
+  Runs `git format-patch` to generate patch files from commits.
+
+  ## Options
+
+    * `:config` - a `Git.Config` struct (default: `Git.Config.new()`)
+    * `:ref` - revision range (required, e.g. `"HEAD~3"`, `"v1.0..v2.0"`)
+    * `:output_directory` - output directory (`-o`)
+    * `:numbered` - number patches in subject (`-n`)
+    * `:cover_letter` - generate cover letter (`--cover-letter`)
+    * `:stdout` - output patches to stdout (`--stdout`)
+    * `:from` - set From header (`--from=`)
+    * `:subject_prefix` - subject prefix (`--subject-prefix=`)
+    * `:no_stat` - suppress diffstat (`--no-stat`)
+    * `:start_number` - start numbering at N (`--start-number=N`)
+    * `:signature` - signature string (`--signature=`)
+    * `:no_signature` - suppress signature (`--no-signature`)
+    * `:quiet` - suppress output of file names (`-q`)
+    * `:zero_commit` - use zero commit hash in From header (`--zero-commit`)
+    * `:base` - record base tree info (`--base=`)
+
+  ## Examples
+
+      Git.format_patch(ref: "HEAD~3", output_directory: "/tmp/patches")
+      Git.format_patch(ref: "v1.0..v2.0", stdout: true)
+
+  """
+  @spec format_patch(keyword()) :: {:ok, [String.t()]} | {:ok, String.t()} | {:error, term()}
+  def format_patch(opts \\ []) do
+    {config, rest} = Keyword.pop(opts, :config, Config.new())
+    command = struct!(Git.Commands.FormatPatch, rest)
+    Git.Command.run(Git.Commands.FormatPatch, command, config)
+  end
+
+  @doc """
+  Runs `git archive` to create an archive of files from a named tree.
+
+  Creates a tar, tar.gz, or zip archive of the repository contents.
+  The `output` option is currently required because git writes binary
+  archive data to stdout when no output file is specified, which cannot
+  be reliably captured as a string.
+
+  ## Options
+
+    * `:config` - a `Git.Config` struct (default: `Git.Config.new()`)
+    * `:ref` - tree-ish to archive (default `"HEAD"`)
+    * `:format` - archive format: `"tar"`, `"tar.gz"`, or `"zip"` (`--format=`)
+    * `:output` - output file path (`--output=`)
+    * `:prefix` - prepend prefix to each filename (`--prefix=`)
+    * `:paths` - restrict archive to these paths (after `--`)
+    * `:remote` - retrieve archive from a remote repository (`--remote=`)
+    * `:worktree_attributes` - use worktree attributes (`--worktree-attributes`)
+    * `:verbose` - report progress to stderr (`-v`)
+
+  ## Examples
+
+      Git.archive(output: "/tmp/repo.tar.gz", format: "tar.gz")
+      Git.archive(output: "/tmp/lib.zip", format: "zip", paths: ["lib/"])
+      Git.archive(output: "/tmp/v1.tar", ref: "v1.0.0", prefix: "project/")
+
+  """
+  @spec archive(keyword()) :: {:ok, :done} | {:error, term()}
+  def archive(opts \\ []) do
+    {config, rest} = Keyword.pop(opts, :config, Config.new())
+    command = struct!(Git.Commands.Archive, rest)
+    Git.Command.run(Git.Commands.Archive, command, config)
+  end
+
+  @doc """
+  Runs `git ls-remote` to list references in a remote repository.
+
+  Returns a list of `Git.LsRemoteEntry` structs containing the SHA
+  and ref name for each reference in the remote.
+
+  ## Options
+
+    * `:config` - a `Git.Config` struct (default: `Git.Config.new()`)
+    * `:remote` - remote name or URL (default: origin)
+    * `:heads` - show only heads (`--heads`)
+    * `:tags` - show only tags (`--tags`)
+    * `:refs` - pattern to filter refs
+    * `:sort` - sort key (`--sort=`)
+    * `:symref` - show underlying ref for symbolic refs (`--symref`)
+    * `:quiet` - suppress output, exit with status only (`-q`)
+    * `:exit_code` - exit with status 2 when no matching refs (`--exit-code`)
+
+  ## Examples
+
+      Git.ls_remote(remote: "origin")
+      Git.ls_remote(heads: true)
+      Git.ls_remote(tags: true, remote: "https://github.com/owner/repo.git")
+
+  """
+  @spec ls_remote(keyword()) :: {:ok, [Git.LsRemoteEntry.t()]} | {:error, term()}
+  def ls_remote(opts \\ []) do
+    {config, rest} = Keyword.pop(opts, :config, Config.new())
+    command = struct!(Git.Commands.LsRemote, rest)
+    Git.Command.run(Git.Commands.LsRemote, command, config)
+  end
+
+  @doc """
+  Runs `git ls-tree` to list the contents of a tree object.
+
+  Returns a list of `Git.TreeEntry` structs with mode, type, SHA, path,
+  and optionally size. When `:name_only` is `true`, returns a list of
+  path strings instead.
+
+  ## Options
+
+    * `:config` - a `Git.Config` struct (default: `Git.Config.new()`)
+    * `:ref` - tree-ish to list (default `"HEAD"`)
+    * `:recursive` - recurse into subtrees (`-r`)
+    * `:tree_only` - show only tree entries, not blobs (`-d`)
+    * `:long` - include object size (`-l`/`--long`)
+    * `:name_only` - show only paths (`--name-only`)
+    * `:abbrev` - abbreviate SHA to N characters (`--abbrev=N`)
+    * `:full_name` - show full path names (`--full-name`)
+    * `:full_tree` - show full tree regardless of current directory (`--full-tree`)
+    * `:path` - restrict to this path (after `--`)
+
+  ## Examples
+
+      Git.ls_tree()
+      Git.ls_tree(recursive: true)
+      Git.ls_tree(name_only: true, ref: "main")
+      Git.ls_tree(long: true, path: "lib/")
+
+  """
+  @spec ls_tree(keyword()) :: {:ok, [Git.TreeEntry.t()] | [String.t()]} | {:error, term()}
+  def ls_tree(opts \\ []) do
+    {config, rest} = Keyword.pop(opts, :config, Config.new())
+    command = struct!(Git.Commands.LsTree, rest)
+    Git.Command.run(Git.Commands.LsTree, command, config)
   end
 end

--- a/lib/git/commands/archive.ex
+++ b/lib/git/commands/archive.ex
@@ -1,0 +1,93 @@
+defmodule Git.Commands.Archive do
+  @moduledoc """
+  Implements the `Git.Command` behaviour for `git archive`.
+
+  Creates an archive of files from a named tree. Supports tar, tar.gz,
+  and zip formats.
+
+  **Limitation:** The `output` option is currently required. When git archive
+  runs without `--output`, it writes binary data to stdout which cannot be
+  reliably captured as a string by `System.cmd/3`. When `output` is specified,
+  git writes directly to the file and stdout is empty.
+  """
+
+  @behaviour Git.Command
+
+  @type t :: %__MODULE__{
+          ref: String.t(),
+          format: String.t() | nil,
+          output: String.t() | nil,
+          prefix: String.t() | nil,
+          paths: [String.t()],
+          remote: String.t() | nil,
+          worktree_attributes: boolean(),
+          verbose: boolean()
+        }
+
+  defstruct ref: "HEAD",
+            format: nil,
+            output: nil,
+            prefix: nil,
+            paths: [],
+            remote: nil,
+            worktree_attributes: false,
+            verbose: false
+
+  @doc """
+  Returns the argument list for `git archive`.
+
+  The tree-ish ref is placed after all flags. Paths are appended after `--`.
+
+  ## Examples
+
+      iex> Git.Commands.Archive.args(%Git.Commands.Archive{})
+      ["archive", "HEAD"]
+
+      iex> Git.Commands.Archive.args(%Git.Commands.Archive{format: "zip", output: "out.zip"})
+      ["archive", "--format=zip", "--output=out.zip", "HEAD"]
+
+      iex> Git.Commands.Archive.args(%Git.Commands.Archive{prefix: "project/", paths: ["lib/"]})
+      ["archive", "--prefix=project/", "HEAD", "--", "lib/"]
+
+      iex> Git.Commands.Archive.args(%Git.Commands.Archive{verbose: true, worktree_attributes: true})
+      ["archive", "-v", "--worktree-attributes", "HEAD"]
+
+  """
+  @spec args(t()) :: [String.t()]
+  @impl true
+  def args(%__MODULE__{} = command) do
+    base = ["archive"]
+
+    base
+    |> maybe_add_flag(command.verbose, "-v")
+    |> maybe_add_option(command.format, "--format=")
+    |> maybe_add_option(command.output, "--output=")
+    |> maybe_add_option(command.prefix, "--prefix=")
+    |> maybe_add_option(command.remote, "--remote=")
+    |> maybe_add_flag(command.worktree_attributes, "--worktree-attributes")
+    |> Kernel.++([command.ref])
+    |> maybe_add_paths(command.paths)
+  end
+
+  @doc """
+  Parses the output of `git archive`.
+
+  On success (exit code 0), returns `{:ok, :done}` since the archive
+  content is written to the output file.
+  On failure, returns `{:error, {stdout, exit_code}}`.
+  """
+  @spec parse_output(String.t(), non_neg_integer()) ::
+          {:ok, :done} | {:error, {String.t(), non_neg_integer()}}
+  @impl true
+  def parse_output(_stdout, 0), do: {:ok, :done}
+  def parse_output(stdout, exit_code), do: {:error, {stdout, exit_code}}
+
+  defp maybe_add_flag(args, true, flag), do: args ++ [flag]
+  defp maybe_add_flag(args, false, _flag), do: args
+
+  defp maybe_add_option(args, nil, _prefix), do: args
+  defp maybe_add_option(args, value, prefix), do: args ++ ["#{prefix}#{value}"]
+
+  defp maybe_add_paths(args, []), do: args
+  defp maybe_add_paths(args, paths), do: args ++ ["--"] ++ paths
+end

--- a/lib/git/commands/describe.ex
+++ b/lib/git/commands/describe.ex
@@ -1,0 +1,106 @@
+defmodule Git.Commands.Describe do
+  @moduledoc """
+  Implements the `Git.Command` behaviour for `git describe`.
+
+  Describes a commit using the most recent tag reachable from it.
+  Supports various formatting options for the description output.
+  """
+
+  @behaviour Git.Command
+
+  @type t :: %__MODULE__{
+          ref: String.t() | nil,
+          tags: boolean(),
+          all: boolean(),
+          long: boolean(),
+          first_parent: boolean(),
+          abbrev: non_neg_integer() | nil,
+          exact_match: boolean(),
+          dirty: boolean() | String.t(),
+          always: boolean(),
+          match: String.t() | nil,
+          exclude: String.t() | nil,
+          candidates: non_neg_integer() | nil,
+          broken: boolean()
+        }
+
+  defstruct ref: nil,
+            tags: false,
+            all: false,
+            long: false,
+            first_parent: false,
+            abbrev: nil,
+            exact_match: false,
+            dirty: false,
+            always: false,
+            match: nil,
+            exclude: nil,
+            candidates: nil,
+            broken: false
+
+  @doc """
+  Returns the argument list for `git describe`.
+
+  ## Examples
+
+      iex> Git.Commands.Describe.args(%Git.Commands.Describe{})
+      ["describe"]
+
+      iex> Git.Commands.Describe.args(%Git.Commands.Describe{tags: true, always: true})
+      ["describe", "--tags", "--always"]
+
+      iex> Git.Commands.Describe.args(%Git.Commands.Describe{abbrev: 4, long: true})
+      ["describe", "--long", "--abbrev=4"]
+
+      iex> Git.Commands.Describe.args(%Git.Commands.Describe{dirty: true})
+      ["describe", "--dirty"]
+
+      iex> Git.Commands.Describe.args(%Git.Commands.Describe{dirty: "-modified"})
+      ["describe", "--dirty=-modified"]
+
+  """
+  @spec args(t()) :: [String.t()]
+  @impl true
+  def args(%__MODULE__{} = command) do
+    ["describe"]
+    |> maybe_add_flag(command.tags, "--tags")
+    |> maybe_add_flag(command.all, "--all")
+    |> maybe_add_flag(command.long, "--long")
+    |> maybe_add_flag(command.first_parent, "--first-parent")
+    |> maybe_add_flag(command.exact_match, "--exact-match")
+    |> maybe_add_flag(command.always, "--always")
+    |> maybe_add_flag(command.broken, "--broken")
+    |> maybe_add_value("--abbrev=", command.abbrev)
+    |> maybe_add_value("--candidates=", command.candidates)
+    |> maybe_add_value("--match=", command.match)
+    |> maybe_add_value("--exclude=", command.exclude)
+    |> maybe_add_dirty(command.dirty)
+    |> maybe_add_ref(command.ref)
+  end
+
+  @doc """
+  Parses the output of `git describe`.
+
+  On success (exit code 0), returns `{:ok, description}` where `description`
+  is the trimmed output string. On failure, returns
+  `{:error, {stdout, exit_code}}`.
+  """
+  @spec parse_output(String.t(), non_neg_integer()) ::
+          {:ok, String.t()} | {:error, {String.t(), non_neg_integer()}}
+  @impl true
+  def parse_output(stdout, 0), do: {:ok, String.trim(stdout)}
+  def parse_output(stdout, exit_code), do: {:error, {stdout, exit_code}}
+
+  defp maybe_add_flag(args, true, flag), do: args ++ [flag]
+  defp maybe_add_flag(args, false, _flag), do: args
+
+  defp maybe_add_value(args, _prefix, nil), do: args
+  defp maybe_add_value(args, prefix, value), do: args ++ ["#{prefix}#{value}"]
+
+  defp maybe_add_dirty(args, false), do: args
+  defp maybe_add_dirty(args, true), do: args ++ ["--dirty"]
+  defp maybe_add_dirty(args, mark) when is_binary(mark), do: args ++ ["--dirty=#{mark}"]
+
+  defp maybe_add_ref(args, nil), do: args
+  defp maybe_add_ref(args, ref), do: args ++ [ref]
+end

--- a/lib/git/commands/format_patch.ex
+++ b/lib/git/commands/format_patch.ex
@@ -1,0 +1,117 @@
+defmodule Git.Commands.FormatPatch do
+  @moduledoc """
+  Implements the `Git.Command` behaviour for `git format-patch`.
+
+  Generates patch files from commits. Supports output to files or stdout,
+  cover letters, numbering, and various patch formatting options.
+  """
+
+  @behaviour Git.Command
+
+  @mode_key :git_format_patch_stdout
+
+  @type t :: %__MODULE__{
+          ref: String.t(),
+          output_directory: String.t() | nil,
+          numbered: boolean(),
+          cover_letter: boolean(),
+          stdout: boolean(),
+          from: String.t() | nil,
+          subject_prefix: String.t() | nil,
+          no_stat: boolean(),
+          start_number: non_neg_integer() | nil,
+          signature: String.t() | nil,
+          no_signature: boolean(),
+          quiet: boolean(),
+          zero_commit: boolean(),
+          base: String.t() | nil
+        }
+
+  defstruct ref: "HEAD~1",
+            output_directory: nil,
+            numbered: false,
+            cover_letter: false,
+            stdout: false,
+            from: nil,
+            subject_prefix: nil,
+            no_stat: false,
+            start_number: nil,
+            signature: nil,
+            no_signature: false,
+            quiet: false,
+            zero_commit: false,
+            base: nil
+
+  @doc """
+  Returns the argument list for `git format-patch`.
+
+  ## Examples
+
+      iex> Git.Commands.FormatPatch.args(%Git.Commands.FormatPatch{ref: "HEAD~3"})
+      ["format-patch", "HEAD~3"]
+
+      iex> Git.Commands.FormatPatch.args(%Git.Commands.FormatPatch{ref: "HEAD~1", stdout: true})
+      ["format-patch", "--stdout", "HEAD~1"]
+
+      iex> Git.Commands.FormatPatch.args(%Git.Commands.FormatPatch{ref: "v1.0..v2.0", output_directory: "/tmp/patches", numbered: true})
+      ["format-patch", "-n", "-o", "/tmp/patches", "v1.0..v2.0"]
+
+  """
+  @spec args(t()) :: [String.t()]
+  @impl true
+  def args(%__MODULE__{} = command) do
+    Process.put(@mode_key, command.stdout)
+
+    ["format-patch"]
+    |> maybe_add_flag(command.stdout, "--stdout")
+    |> maybe_add_flag(command.numbered, "-n")
+    |> maybe_add_flag(command.cover_letter, "--cover-letter")
+    |> maybe_add_flag(command.no_stat, "--no-stat")
+    |> maybe_add_flag(command.no_signature, "--no-signature")
+    |> maybe_add_flag(command.quiet, "-q")
+    |> maybe_add_flag(command.zero_commit, "--zero-commit")
+    |> maybe_add_output_directory(command.output_directory)
+    |> maybe_add_value("--from=", command.from)
+    |> maybe_add_value("--subject-prefix=", command.subject_prefix)
+    |> maybe_add_value("--start-number=", command.start_number)
+    |> maybe_add_value("--signature=", command.signature)
+    |> maybe_add_value("--base=", command.base)
+    |> Kernel.++([command.ref])
+  end
+
+  @doc """
+  Parses the output of `git format-patch`.
+
+  When stdout mode is active, returns `{:ok, patch_content}`.
+  Otherwise, returns `{:ok, [file_path]}` with the list of generated
+  patch file paths.
+
+  On failure, returns `{:error, {stdout, exit_code}}`.
+  """
+  @spec parse_output(String.t(), non_neg_integer()) ::
+          {:ok, String.t()} | {:ok, [String.t()]} | {:error, {String.t(), non_neg_integer()}}
+  @impl true
+  def parse_output(stdout, 0) do
+    if Process.get(@mode_key, false) do
+      {:ok, stdout}
+    else
+      files =
+        stdout
+        |> String.split("\n", trim: true)
+        |> Enum.map(&String.trim/1)
+
+      {:ok, files}
+    end
+  end
+
+  def parse_output(stdout, exit_code), do: {:error, {stdout, exit_code}}
+
+  defp maybe_add_flag(args, true, flag), do: args ++ [flag]
+  defp maybe_add_flag(args, false, _flag), do: args
+
+  defp maybe_add_value(args, _prefix, nil), do: args
+  defp maybe_add_value(args, prefix, value), do: args ++ ["#{prefix}#{value}"]
+
+  defp maybe_add_output_directory(args, nil), do: args
+  defp maybe_add_output_directory(args, dir), do: args ++ ["-o", dir]
+end

--- a/lib/git/commands/ls_remote.ex
+++ b/lib/git/commands/ls_remote.ex
@@ -1,0 +1,121 @@
+defmodule Git.Commands.LsRemote do
+  @moduledoc """
+  Implements the `Git.Command` behaviour for `git ls-remote`.
+
+  Lists references in a remote repository. Parses the output into
+  a list of `Git.LsRemoteEntry` structs containing the SHA and ref name.
+
+  Symref lines (from `--symref`) are included with `sha` set to `nil`.
+  """
+
+  @behaviour Git.Command
+
+  alias Git.LsRemoteEntry
+
+  @type t :: %__MODULE__{
+          remote: String.t() | nil,
+          heads: boolean(),
+          tags: boolean(),
+          refs: String.t() | nil,
+          sort: String.t() | nil,
+          symref: boolean(),
+          quiet: boolean(),
+          exit_code: boolean()
+        }
+
+  defstruct remote: nil,
+            heads: false,
+            tags: false,
+            refs: nil,
+            sort: nil,
+            symref: false,
+            quiet: false,
+            exit_code: false
+
+  @doc """
+  Returns the argument list for `git ls-remote`.
+
+  The remote name/URL is placed after flags. The refs pattern, if given,
+  is appended at the end.
+
+  ## Examples
+
+      iex> Git.Commands.LsRemote.args(%Git.Commands.LsRemote{})
+      ["ls-remote"]
+
+      iex> Git.Commands.LsRemote.args(%Git.Commands.LsRemote{heads: true, tags: true})
+      ["ls-remote", "--heads", "--tags"]
+
+      iex> Git.Commands.LsRemote.args(%Git.Commands.LsRemote{remote: "origin", refs: "refs/heads/main"})
+      ["ls-remote", "origin", "refs/heads/main"]
+
+      iex> Git.Commands.LsRemote.args(%Git.Commands.LsRemote{symref: true, sort: "version:refname"})
+      ["ls-remote", "--symref", "--sort=version:refname"]
+
+  """
+  @spec args(t()) :: [String.t()]
+  @impl true
+  def args(%__MODULE__{} = command) do
+    base = ["ls-remote"]
+
+    base
+    |> maybe_add_flag(command.heads, "--heads")
+    |> maybe_add_flag(command.tags, "--tags")
+    |> maybe_add_flag(command.symref, "--symref")
+    |> maybe_add_flag(command.quiet, "-q")
+    |> maybe_add_flag(command.exit_code, "--exit-code")
+    |> maybe_add_option(command.sort, "--sort=")
+    |> maybe_add_remote(command.remote)
+    |> maybe_add_refs(command.refs)
+  end
+
+  @doc """
+  Parses the output of `git ls-remote`.
+
+  On success (exit code 0), parses tab-separated `SHA\\tref` lines into
+  a list of `Git.LsRemoteEntry` structs. Symref lines (prefixed with
+  `ref:`) are included with `sha` set to `nil`.
+
+  Exit code 2 with `--exit-code` means no matching refs and returns
+  `{:ok, []}`.
+
+  Returns `{:error, {stdout, exit_code}}` on other failures.
+  """
+  @spec parse_output(String.t(), non_neg_integer()) ::
+          {:ok, [LsRemoteEntry.t()]} | {:error, {String.t(), non_neg_integer()}}
+  @impl true
+  def parse_output(stdout, 0), do: {:ok, parse_lines(stdout)}
+  def parse_output(_stdout, 2), do: {:ok, []}
+  def parse_output(stdout, exit_code), do: {:error, {stdout, exit_code}}
+
+  defp parse_lines(stdout) do
+    stdout
+    |> String.split("\n", trim: true)
+    |> Enum.map(&parse_line/1)
+  end
+
+  defp parse_line(line) do
+    case String.split(line, "\t", parts: 2) do
+      ["ref: " <> symref_target, ref] ->
+        %LsRemoteEntry{sha: nil, ref: "ref: #{symref_target}\t#{ref}"}
+
+      [sha, ref] ->
+        %LsRemoteEntry{sha: sha, ref: ref}
+
+      _ ->
+        %LsRemoteEntry{sha: nil, ref: line}
+    end
+  end
+
+  defp maybe_add_flag(args, true, flag), do: args ++ [flag]
+  defp maybe_add_flag(args, false, _flag), do: args
+
+  defp maybe_add_option(args, nil, _prefix), do: args
+  defp maybe_add_option(args, value, prefix), do: args ++ ["#{prefix}#{value}"]
+
+  defp maybe_add_remote(args, nil), do: args
+  defp maybe_add_remote(args, remote), do: args ++ [remote]
+
+  defp maybe_add_refs(args, nil), do: args
+  defp maybe_add_refs(args, refs), do: args ++ [refs]
+end

--- a/lib/git/commands/ls_tree.ex
+++ b/lib/git/commands/ls_tree.ex
@@ -1,0 +1,159 @@
+defmodule Git.Commands.LsTree do
+  @moduledoc """
+  Implements the `Git.Command` behaviour for `git ls-tree`.
+
+  Lists the contents of a tree object, showing the mode, type, name,
+  and optionally size of each object. Parses output into a list of
+  `Git.TreeEntry` structs or plain path strings when `--name-only` is used.
+  """
+
+  @behaviour Git.Command
+
+  alias Git.TreeEntry
+
+  @type t :: %__MODULE__{
+          ref: String.t(),
+          recursive: boolean(),
+          tree_only: boolean(),
+          long: boolean(),
+          name_only: boolean(),
+          abbrev: non_neg_integer() | nil,
+          full_name: boolean(),
+          full_tree: boolean(),
+          path: String.t() | nil
+        }
+
+  defstruct ref: "HEAD",
+            recursive: false,
+            tree_only: false,
+            long: false,
+            name_only: false,
+            abbrev: nil,
+            full_name: false,
+            full_tree: false,
+            path: nil
+
+  @doc """
+  Returns the argument list for `git ls-tree`.
+
+  The tree-ish ref is placed after flags. An optional path filter is
+  appended after `--`.
+
+  ## Examples
+
+      iex> Git.Commands.LsTree.args(%Git.Commands.LsTree{})
+      ["ls-tree", "HEAD"]
+
+      iex> Git.Commands.LsTree.args(%Git.Commands.LsTree{recursive: true, long: true})
+      ["ls-tree", "-r", "-l", "HEAD"]
+
+      iex> Git.Commands.LsTree.args(%Git.Commands.LsTree{name_only: true, ref: "main"})
+      ["ls-tree", "--name-only", "main"]
+
+      iex> Git.Commands.LsTree.args(%Git.Commands.LsTree{path: "lib/"})
+      ["ls-tree", "HEAD", "--", "lib/"]
+
+      iex> Git.Commands.LsTree.args(%Git.Commands.LsTree{abbrev: 8})
+      ["ls-tree", "--abbrev=8", "HEAD"]
+
+  """
+  @spec args(t()) :: [String.t()]
+  @impl true
+  def args(%__MODULE__{} = command) do
+    base = ["ls-tree"]
+
+    base
+    |> maybe_add_flag(command.recursive, "-r")
+    |> maybe_add_flag(command.tree_only, "-d")
+    |> maybe_add_flag(command.long, "-l")
+    |> maybe_add_flag(command.name_only, "--name-only")
+    |> maybe_add_abbrev(command.abbrev)
+    |> maybe_add_flag(command.full_name, "--full-name")
+    |> maybe_add_flag(command.full_tree, "--full-tree")
+    |> Kernel.++([command.ref])
+    |> maybe_add_path(command.path)
+  end
+
+  @doc """
+  Parses the output of `git ls-tree`.
+
+  On success (exit code 0), parses each line into a `Git.TreeEntry` struct.
+  When `name_only` mode was used (detected by the absence of tabs in output),
+  returns `{:ok, [String.t()]}` with just the path names.
+
+  The default format is `mode type sha\\tpath`.
+  With `--long`, the format is `mode type sha    size\\tpath` where size
+  is right-justified with spaces.
+
+  Returns `{:error, {stdout, exit_code}}` on failure.
+  """
+  @spec parse_output(String.t(), non_neg_integer()) ::
+          {:ok, [TreeEntry.t()] | [String.t()]} | {:error, {String.t(), non_neg_integer()}}
+  @impl true
+  def parse_output(stdout, 0) do
+    lines = String.split(stdout, "\n", trim: true)
+
+    case lines do
+      [] ->
+        {:ok, []}
+
+      [first | _] ->
+        if String.contains?(first, "\t") do
+          {:ok, Enum.map(lines, &parse_tree_line/1)}
+        else
+          {:ok, Enum.map(lines, &String.trim/1)}
+        end
+    end
+  end
+
+  def parse_output(stdout, exit_code), do: {:error, {stdout, exit_code}}
+
+  defp parse_tree_line(line) do
+    # Format: "mode type sha\tpath" or "mode type sha    size\tpath"
+    [meta, path] = String.split(line, "\t", parts: 2)
+    parts = String.split(meta, ~r/\s+/, trim: true)
+
+    case parts do
+      [mode, type, sha, size] ->
+        %TreeEntry{
+          mode: mode,
+          type: parse_type(type),
+          sha: sha,
+          path: path,
+          size: parse_size(size)
+        }
+
+      [mode, type, sha] ->
+        %TreeEntry{
+          mode: mode,
+          type: parse_type(type),
+          sha: sha,
+          path: path,
+          size: nil
+        }
+    end
+  end
+
+  defp parse_type("blob"), do: :blob
+  defp parse_type("tree"), do: :tree
+  defp parse_type("commit"), do: :commit
+  defp parse_type(other), do: String.to_atom(other)
+
+  defp parse_size("-"), do: nil
+
+  defp parse_size(size_str) do
+    case Integer.parse(size_str) do
+      {size, _} -> size
+      :error -> nil
+    end
+  end
+
+  defp maybe_add_flag(args, true, flag), do: args ++ [flag]
+  defp maybe_add_flag(args, false, _flag), do: args
+
+  defp maybe_add_abbrev(args, nil), do: args
+  defp maybe_add_abbrev(args, n) when is_integer(n), do: args ++ ["--abbrev=#{n}"]
+
+  defp maybe_add_path(args, nil), do: args
+  defp maybe_add_path(args, path), do: args ++ ["--", path]
+end

--- a/lib/git/commands/shortlog.ex
+++ b/lib/git/commands/shortlog.ex
@@ -1,0 +1,113 @@
+defmodule Git.Commands.Shortlog do
+  @moduledoc """
+  Implements the `Git.Command` behaviour for `git shortlog`.
+
+  Summarizes `git log` output grouped by author. Supports summary mode
+  (count only), numbered sorting, email display, and ref ranges.
+  """
+
+  @behaviour Git.Command
+
+  alias Git.ShortlogEntry
+
+  @type t :: %__MODULE__{
+          numbered: boolean(),
+          summary: boolean(),
+          email: boolean(),
+          group: String.t() | nil,
+          ref: String.t() | nil,
+          max_count: non_neg_integer() | nil,
+          since: String.t() | nil,
+          until_date: String.t() | nil,
+          all: boolean()
+        }
+
+  defstruct numbered: false,
+            summary: false,
+            email: false,
+            group: nil,
+            ref: nil,
+            max_count: nil,
+            since: nil,
+            until_date: nil,
+            all: false
+
+  @doc """
+  Returns the argument list for `git shortlog`.
+
+  ## Examples
+
+      iex> Git.Commands.Shortlog.args(%Git.Commands.Shortlog{})
+      ["shortlog"]
+
+      iex> Git.Commands.Shortlog.args(%Git.Commands.Shortlog{summary: true, numbered: true})
+      ["shortlog", "-s", "-n"]
+
+      iex> Git.Commands.Shortlog.args(%Git.Commands.Shortlog{email: true, ref: "v1.0..HEAD"})
+      ["shortlog", "-e", "v1.0..HEAD"]
+
+      iex> Git.Commands.Shortlog.args(%Git.Commands.Shortlog{max_count: 10, group: "author"})
+      ["shortlog", "--max-count=10", "--group=author"]
+
+  """
+  @spec args(t()) :: [String.t()]
+  @impl true
+  def args(%__MODULE__{} = command) do
+    ["shortlog"]
+    |> maybe_add_flag(command.summary, "-s")
+    |> maybe_add_flag(command.numbered, "-n")
+    |> maybe_add_flag(command.email, "-e")
+    |> maybe_add_flag(command.all, "--all")
+    |> maybe_add_value("--max-count=", command.max_count)
+    |> maybe_add_value("--since=", command.since)
+    |> maybe_add_value("--until=", command.until_date)
+    |> maybe_add_value("--group=", command.group)
+    |> maybe_add_ref(command.ref)
+  end
+
+  @doc """
+  Parses the output of `git shortlog`.
+
+  When summary mode is detected (tab-separated count and author), uses
+  `ShortlogEntry.parse_summary/1`. Otherwise uses `ShortlogEntry.parse_full/1`.
+
+  Returns `{:ok, [%Git.ShortlogEntry{}]}` on success or
+  `{:error, {stdout, exit_code}}` on failure.
+  """
+  @spec parse_output(String.t(), non_neg_integer()) ::
+          {:ok, [ShortlogEntry.t()]} | {:error, {String.t(), non_neg_integer()}}
+  @impl true
+  def parse_output(stdout, 0) do
+    trimmed = String.trim(stdout)
+
+    if trimmed == "" do
+      {:ok, []}
+    else
+      entries =
+        if summary_format?(trimmed) do
+          ShortlogEntry.parse_summary(stdout)
+        else
+          ShortlogEntry.parse_full(stdout)
+        end
+
+      {:ok, entries}
+    end
+  end
+
+  def parse_output(stdout, exit_code), do: {:error, {stdout, exit_code}}
+
+  # Summary format lines look like "   count\tAuthor Name"
+  defp summary_format?(output) do
+    first_line = output |> String.split("\n", parts: 2) |> hd()
+    Regex.match?(~r/^\s*\d+\t/, first_line)
+  end
+
+  defp maybe_add_flag(args, true, flag), do: args ++ [flag]
+  defp maybe_add_flag(args, false, _flag), do: args
+
+  defp maybe_add_value(args, _prefix, nil), do: args
+  defp maybe_add_value(args, prefix, value), do: args ++ ["#{prefix}#{value}"]
+
+  defp maybe_add_ref(args, nil), do: args
+  defp maybe_add_ref(args, ref), do: args ++ [ref]
+end

--- a/lib/git/commands/submodule.ex
+++ b/lib/git/commands/submodule.ex
@@ -1,0 +1,245 @@
+defmodule Git.Commands.Submodule do
+  @moduledoc """
+  Implements the `Git.Command` behaviour for `git submodule`.
+
+  Supports status (default), init, update, add, deinit, sync, summary,
+  set-branch, and set-url subcommands.
+
+  The `foreach` subcommand is intentionally not supported because it requires
+  an arbitrary shell command string, which does not fit the structured command
+  model and would introduce shell injection concerns.
+  """
+
+  @behaviour Git.Command
+
+  alias Git.SubmoduleEntry
+
+  @type t :: %__MODULE__{
+          status: boolean(),
+          init: boolean(),
+          update: boolean(),
+          add_url: String.t() | nil,
+          add_path: String.t() | nil,
+          deinit: String.t() | nil,
+          sync: boolean(),
+          summary: boolean(),
+          set_branch: String.t() | nil,
+          set_url: String.t() | nil,
+          path: String.t() | nil,
+          recursive: boolean(),
+          force: boolean(),
+          remote: boolean(),
+          merge: boolean(),
+          rebase: boolean(),
+          depth: non_neg_integer() | nil,
+          reference: String.t() | nil,
+          name: String.t() | nil,
+          branch: String.t() | nil,
+          quiet: boolean(),
+          all: boolean()
+        }
+
+  defstruct status: true,
+            init: false,
+            update: false,
+            add_url: nil,
+            add_path: nil,
+            deinit: nil,
+            sync: false,
+            summary: false,
+            set_branch: nil,
+            set_url: nil,
+            path: nil,
+            recursive: false,
+            force: false,
+            remote: false,
+            merge: false,
+            rebase: false,
+            depth: nil,
+            reference: nil,
+            name: nil,
+            branch: nil,
+            quiet: false,
+            all: false
+
+  # Process dictionary key used to communicate the operation mode from args/1
+  # to parse_output/2. Both are called from the same process inside
+  # Git.Command.run/3, so this is safe even with async tests.
+  @mode_key :__git_submodule_mode__
+
+  @doc """
+  Returns the argument list for `git submodule`.
+
+  - If `:add_url` is set, builds `git submodule add [options] <url> [<path>]`.
+  - If `:deinit` is set, builds `git submodule deinit [--force] [--all] <path>`.
+  - If `:init` is true, builds `git submodule init [<path>]`.
+  - If `:update` is true, builds `git submodule update [options] [<path>]`.
+  - If `:sync` is true, builds `git submodule sync [--recursive] [<path>]`.
+  - If `:summary` is true, builds `git submodule summary [<path>]`.
+  - If `:set_branch` is set, builds `git submodule set-branch -b <branch> <path>`.
+  - If `:set_url` is set, builds `git submodule set-url <path> <url>`.
+  - Otherwise, shows status with `git submodule status [--recursive] [<path>]`.
+
+  ## Examples
+
+      iex> Git.Commands.Submodule.args(%Git.Commands.Submodule{})
+      ["submodule", "status"]
+
+      iex> Git.Commands.Submodule.args(%Git.Commands.Submodule{init: true})
+      ["submodule", "init"]
+
+      iex> Git.Commands.Submodule.args(%Git.Commands.Submodule{update: true, recursive: true})
+      ["submodule", "update", "--recursive"]
+
+      iex> Git.Commands.Submodule.args(%Git.Commands.Submodule{add_url: "https://example.com/lib.git", add_path: "vendor/lib"})
+      ["submodule", "add", "https://example.com/lib.git", "vendor/lib"]
+
+      iex> Git.Commands.Submodule.args(%Git.Commands.Submodule{deinit: "vendor/lib", force: true})
+      ["submodule", "deinit", "--force", "vendor/lib"]
+
+      iex> Git.Commands.Submodule.args(%Git.Commands.Submodule{sync: true, recursive: true})
+      ["submodule", "sync", "--recursive"]
+
+  """
+  @spec args(t()) :: [String.t()]
+  @impl true
+  def args(%__MODULE__{add_url: url} = command) when is_binary(url) do
+    Process.put(@mode_key, :mutation)
+
+    base = ["submodule", "add"]
+
+    base
+    |> maybe_add_flag(command.quiet, "-q")
+    |> maybe_add_flag(command.force, "--force")
+    |> maybe_add_option("--depth", command.depth)
+    |> maybe_add_option("--reference", command.reference)
+    |> maybe_add_option("--name", command.name)
+    |> maybe_add_option("-b", command.branch)
+    |> Kernel.++([url])
+    |> maybe_add_value(command.add_path)
+  end
+
+  def args(%__MODULE__{deinit: path} = command) when is_binary(path) do
+    Process.put(@mode_key, :mutation)
+
+    ["submodule", "deinit"]
+    |> maybe_add_flag(command.quiet, "-q")
+    |> maybe_add_flag(command.force, "--force")
+    |> maybe_add_flag(command.all, "--all")
+    |> Kernel.++([path])
+  end
+
+  def args(%__MODULE__{set_branch: branch_name} = command) when is_binary(branch_name) do
+    Process.put(@mode_key, :mutation)
+
+    ["submodule", "set-branch", "-b", branch_name]
+    |> maybe_add_value(command.path)
+  end
+
+  def args(%__MODULE__{set_url: url} = command) when is_binary(url) do
+    Process.put(@mode_key, :mutation)
+
+    ["submodule", "set-url"]
+    |> maybe_add_value(command.path)
+    |> Kernel.++([url])
+  end
+
+  def args(%__MODULE__{init: true} = command) do
+    Process.put(@mode_key, :mutation)
+
+    ["submodule", "init"]
+    |> maybe_add_flag(command.quiet, "-q")
+    |> maybe_add_value(command.path)
+  end
+
+  def args(%__MODULE__{update: true} = command) do
+    Process.put(@mode_key, :mutation)
+
+    ["submodule", "update"]
+    |> maybe_add_flag(command.quiet, "-q")
+    |> maybe_add_flag(command.force, "--force")
+    |> maybe_add_flag(command.remote, "--remote")
+    |> maybe_add_flag(command.merge, "--merge")
+    |> maybe_add_flag(command.rebase, "--rebase")
+    |> maybe_add_flag(command.recursive, "--recursive")
+    |> maybe_add_option("--depth", command.depth)
+    |> maybe_add_option("--reference", command.reference)
+    |> maybe_add_value(command.path)
+  end
+
+  def args(%__MODULE__{sync: true} = command) do
+    Process.put(@mode_key, :mutation)
+
+    ["submodule", "sync"]
+    |> maybe_add_flag(command.quiet, "-q")
+    |> maybe_add_flag(command.recursive, "--recursive")
+    |> maybe_add_value(command.path)
+  end
+
+  def args(%__MODULE__{summary: true} = command) do
+    Process.put(@mode_key, :summary)
+
+    ["submodule", "summary"]
+    |> maybe_add_value(command.path)
+  end
+
+  def args(%__MODULE__{} = command) do
+    Process.put(@mode_key, :list)
+
+    ["submodule", "status"]
+    |> maybe_add_flag(command.recursive, "--recursive")
+    |> maybe_add_value(command.path)
+  end
+
+  @doc """
+  Parses the output of `git submodule`.
+
+  For status operations (exit 0), parses each line into a `Git.SubmoduleEntry`
+  struct. For mutation operations (exit 0), returns `{:ok, :done}`. For summary
+  operations (exit 0), returns `{:ok, stdout}` with the raw summary text.
+  On failure, returns `{:error, {stdout, exit_code}}`.
+  """
+  @spec parse_output(String.t(), non_neg_integer()) ::
+          {:ok, [SubmoduleEntry.t()]}
+          | {:ok, :done}
+          | {:ok, String.t()}
+          | {:error, {String.t(), non_neg_integer()}}
+  @impl true
+  def parse_output(stdout, 0) do
+    mode = Process.get(@mode_key, :list)
+
+    case mode do
+      :mutation ->
+        {:ok, :done}
+
+      :summary ->
+        {:ok, stdout}
+
+      :list ->
+        if String.trim(stdout) == "" do
+          {:ok, []}
+        else
+          {:ok, SubmoduleEntry.parse(stdout)}
+        end
+    end
+  end
+
+  def parse_output(stdout, exit_code), do: {:error, {stdout, exit_code}}
+
+  @spec maybe_add_flag([String.t()], boolean(), String.t()) :: [String.t()]
+  defp maybe_add_flag(args, false, _flag), do: args
+  defp maybe_add_flag(args, true, flag), do: args ++ [flag]
+
+  @spec maybe_add_option([String.t()], String.t(), term()) :: [String.t()]
+  defp maybe_add_option(args, _flag, nil), do: args
+
+  defp maybe_add_option(args, flag, value) when is_integer(value),
+    do: args ++ [flag, Integer.to_string(value)]
+
+  defp maybe_add_option(args, flag, value) when is_binary(value),
+    do: args ++ [flag, value]
+
+  @spec maybe_add_value([String.t()], String.t() | nil) :: [String.t()]
+  defp maybe_add_value(args, nil), do: args
+  defp maybe_add_value(args, value), do: args ++ [value]
+end

--- a/lib/git/ls_remote_entry.ex
+++ b/lib/git/ls_remote_entry.ex
@@ -1,0 +1,18 @@
+defmodule Git.LsRemoteEntry do
+  @moduledoc """
+  Struct representing a single entry from `git ls-remote` output.
+
+  Each entry contains the object SHA and the ref name. Symref lines
+  (from `--symref`) are included with `sha` set to `nil`.
+  """
+
+  @type t :: %__MODULE__{
+          sha: String.t() | nil,
+          ref: String.t()
+        }
+
+  defstruct [
+    :sha,
+    :ref
+  ]
+end

--- a/lib/git/repo.ex
+++ b/lib/git/repo.ex
@@ -466,6 +466,17 @@ defmodule Git.Repo do
   end
 
   @doc """
+  Runs `git submodule` on the repository.
+
+  See `Git.submodule/1` for available options.
+  """
+  @spec submodule(t(), keyword()) ::
+          {:ok, [Git.SubmoduleEntry.t()]} | {:ok, :done} | {:ok, String.t()} | {:error, term()}
+  def submodule(%__MODULE__{} = repo, opts \\ []) do
+    Git.submodule(Keyword.put(opts, :config, repo.config))
+  end
+
+  @doc """
   Runs `git config` on the repository.
 
   See `Git.git_config/1` for available options.
@@ -515,5 +526,67 @@ defmodule Git.Repo do
   @spec grep(t(), String.t(), keyword()) :: {:ok, [Git.GrepResult.t()]} | {:error, term()}
   def grep(%__MODULE__{} = repo, pattern, opts \\ []) do
     Git.grep(pattern, Keyword.put(opts, :config, repo.config))
+  end
+
+  @doc """
+  Runs `git describe` on the repository.
+
+  See `Git.describe/1` for available options.
+  """
+  @spec describe(t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def describe(%__MODULE__{} = repo, opts \\ []) do
+    Git.describe(Keyword.put(opts, :config, repo.config))
+  end
+
+  @doc """
+  Runs `git shortlog` on the repository.
+
+  See `Git.shortlog/1` for available options.
+  """
+  @spec shortlog(t(), keyword()) :: {:ok, [Git.ShortlogEntry.t()]} | {:error, term()}
+  def shortlog(%__MODULE__{} = repo, opts \\ []) do
+    Git.shortlog(Keyword.put(opts, :config, repo.config))
+  end
+
+  @doc """
+  Runs `git format-patch` on the repository.
+
+  See `Git.format_patch/1` for available options.
+  """
+  @spec format_patch(t(), keyword()) ::
+          {:ok, [String.t()]} | {:ok, String.t()} | {:error, term()}
+  def format_patch(%__MODULE__{} = repo, opts \\ []) do
+    Git.format_patch(Keyword.put(opts, :config, repo.config))
+  end
+
+  @doc """
+  Runs `git archive` on the repository.
+
+  See `Git.archive/1` for available options.
+  """
+  @spec archive(t(), keyword()) :: {:ok, :done} | {:error, term()}
+  def archive(%__MODULE__{} = repo, opts \\ []) do
+    Git.archive(Keyword.put(opts, :config, repo.config))
+  end
+
+  @doc """
+  Runs `git ls-remote` on the repository.
+
+  See `Git.ls_remote/1` for available options.
+  """
+  @spec ls_remote(t(), keyword()) :: {:ok, [Git.LsRemoteEntry.t()]} | {:error, term()}
+  def ls_remote(%__MODULE__{} = repo, opts \\ []) do
+    Git.ls_remote(Keyword.put(opts, :config, repo.config))
+  end
+
+  @doc """
+  Runs `git ls-tree` on the repository.
+
+  See `Git.ls_tree/1` for available options.
+  """
+  @spec ls_tree(t(), keyword()) ::
+          {:ok, [Git.TreeEntry.t()] | [String.t()]} | {:error, term()}
+  def ls_tree(%__MODULE__{} = repo, opts \\ []) do
+    Git.ls_tree(Keyword.put(opts, :config, repo.config))
   end
 end

--- a/lib/git/shortlog_entry.ex
+++ b/lib/git/shortlog_entry.ex
@@ -1,0 +1,123 @@
+defmodule Git.ShortlogEntry do
+  @moduledoc """
+  Parsed representation of a git shortlog entry.
+
+  Contains the author name, optional email, commit count, and list of
+  commit subjects (empty when `summary: true` is used).
+  """
+
+  @type t :: %__MODULE__{
+          author: String.t(),
+          email: String.t() | nil,
+          count: non_neg_integer(),
+          commits: [String.t()]
+        }
+
+  defstruct author: "",
+            email: nil,
+            count: 0,
+            commits: []
+
+  @doc """
+  Parses the output of `git shortlog` into a list of `Git.ShortlogEntry` structs.
+
+  Handles both summary mode (`-s`) and full mode output.
+
+  Summary mode lines have the form:
+
+      count\\tAuthor Name
+      count\\tAuthor Name <email>
+
+  Full mode output has the form:
+
+      Author Name (count):
+            commit subject 1
+            commit subject 2
+
+  ## Examples
+
+      iex> Git.ShortlogEntry.parse_summary("     3\\tAlice\\n     1\\tBob\\n")
+      [
+        %Git.ShortlogEntry{author: "Alice", email: nil, count: 3, commits: []},
+        %Git.ShortlogEntry{author: "Bob", email: nil, count: 1, commits: []}
+      ]
+
+      iex> Git.ShortlogEntry.parse_summary("")
+      []
+
+  """
+  @spec parse_summary(String.t()) :: [t()]
+  def parse_summary(output) do
+    output
+    |> String.split("\n", trim: true)
+    |> Enum.map(&parse_summary_line/1)
+  end
+
+  @doc """
+  Parses full (non-summary) shortlog output into entries with commit lists.
+  """
+  @spec parse_full(String.t()) :: [t()]
+  def parse_full(output) do
+    output
+    |> String.split("\n")
+    |> parse_full_lines([])
+    |> Enum.reverse()
+  end
+
+  defp parse_summary_line(line) do
+    trimmed = String.trim(line)
+
+    case Regex.run(~r/^(\d+)\t(.+)$/, trimmed) do
+      [_, count_str, rest] ->
+        count = String.to_integer(count_str)
+        {author, email} = parse_author_email(rest)
+        %__MODULE__{author: author, email: email, count: count, commits: []}
+
+      nil ->
+        %__MODULE__{author: trimmed, count: 0, commits: []}
+    end
+  end
+
+  defp parse_full_lines([], acc), do: acc
+
+  defp parse_full_lines([line | rest], acc) do
+    case Regex.run(~r/^(.+?)\s+\((\d+)\):$/, line) do
+      [_, author_part, count_str] ->
+        {author, email} = parse_author_email(author_part)
+        count = String.to_integer(count_str)
+        {commits, remaining} = collect_commits(rest, [])
+
+        entry = %__MODULE__{
+          author: author,
+          email: email,
+          count: count,
+          commits: Enum.reverse(commits)
+        }
+
+        parse_full_lines(remaining, [entry | acc])
+
+      nil ->
+        # Skip blank or unparseable lines
+        parse_full_lines(rest, acc)
+    end
+  end
+
+  defp collect_commits([], acc), do: {acc, []}
+
+  defp collect_commits([line | rest] = lines, acc) do
+    trimmed = String.trim(line)
+
+    if trimmed == "" or not String.starts_with?(line, "      ") do
+      {acc, lines}
+    else
+      collect_commits(rest, [trimmed | acc])
+    end
+  end
+
+  defp parse_author_email(str) do
+    case Regex.run(~r/^(.+?)\s+<([^>]+)>$/, str) do
+      [_, author, email] -> {author, email}
+      nil -> {str, nil}
+    end
+  end
+end

--- a/lib/git/submodule_entry.ex
+++ b/lib/git/submodule_entry.ex
@@ -1,0 +1,87 @@
+defmodule Git.SubmoduleEntry do
+  @moduledoc """
+  Parsed representation of a git submodule status entry.
+
+  Each entry contains the SHA, path, an optional describe string
+  (tag describe for the SHA), and a status indicating the submodule state.
+
+  ## Status values
+
+    * `:current` - submodule is checked out at the recorded commit
+    * `:modified` - submodule has a different commit checked out
+    * `:uninitialized` - submodule is not initialized
+    * `:conflict` - submodule has merge conflicts
+  """
+
+  @type status :: :current | :modified | :uninitialized | :conflict
+
+  @type t :: %__MODULE__{
+          sha: String.t(),
+          path: String.t(),
+          describe: String.t() | nil,
+          status: status()
+        }
+
+  defstruct [:sha, :path, :describe, :status]
+
+  @doc """
+  Parses the output of `git submodule status` into a list of
+  `Git.SubmoduleEntry` structs.
+
+  Each line has the format:
+
+      <status_char><sha> <path> (<describe>)
+
+  where `<status_char>` is a space (current), `+` (modified),
+  `-` (uninitialized), or `U` (conflict), and the describe portion
+  is optional.
+
+  ## Examples
+
+      iex> Git.SubmoduleEntry.parse(" abc1234 lib/sub (v1.0.0)\\n")
+      [%Git.SubmoduleEntry{sha: "abc1234", path: "lib/sub", describe: "v1.0.0", status: :current}]
+
+      iex> Git.SubmoduleEntry.parse("+def5678 vendor/dep\\n")
+      [%Git.SubmoduleEntry{sha: "def5678", path: "vendor/dep", describe: nil, status: :modified}]
+
+      iex> Git.SubmoduleEntry.parse("")
+      []
+
+  """
+  @spec parse(String.t()) :: [t()]
+  def parse(output) do
+    output
+    |> String.split("\n", trim: true)
+    |> Enum.map(&parse_line/1)
+  end
+
+  @spec parse_line(String.t()) :: t()
+  defp parse_line(line) do
+    case Regex.run(~r/^([ +\-U])([0-9a-f]+)\s+(\S+)(?:\s+\((.+)\))?/, line) do
+      [_, status_char, sha, path, describe] ->
+        %__MODULE__{
+          sha: sha,
+          path: path,
+          describe: if(describe == "", do: nil, else: describe),
+          status: parse_status(status_char)
+        }
+
+      [_, status_char, sha, path] ->
+        %__MODULE__{
+          sha: sha,
+          path: path,
+          describe: nil,
+          status: parse_status(status_char)
+        }
+
+      nil ->
+        %__MODULE__{sha: "", path: String.trim(line), describe: nil, status: :current}
+    end
+  end
+
+  @spec parse_status(String.t()) :: status()
+  defp parse_status(" "), do: :current
+  defp parse_status("+"), do: :modified
+  defp parse_status("-"), do: :uninitialized
+  defp parse_status("U"), do: :conflict
+end

--- a/lib/git/tree_entry.ex
+++ b/lib/git/tree_entry.ex
@@ -1,0 +1,24 @@
+defmodule Git.TreeEntry do
+  @moduledoc """
+  Struct representing a single entry from `git ls-tree` output.
+
+  Each entry contains the file mode, object type, SHA, path, and
+  optionally the object size (when `--long` is used).
+  """
+
+  @type t :: %__MODULE__{
+          mode: String.t(),
+          type: :blob | :tree | :commit,
+          sha: String.t(),
+          path: String.t(),
+          size: non_neg_integer() | nil
+        }
+
+  defstruct [
+    :mode,
+    :type,
+    :sha,
+    :path,
+    :size
+  ]
+end

--- a/test/git/commands/archive_test.exs
+++ b/test/git/commands/archive_test.exs
@@ -1,0 +1,128 @@
+defmodule Git.ArchiveTest do
+  use ExUnit.Case, async: true
+
+  alias Git.Commands.Archive
+
+  @env [
+    {"GIT_AUTHOR_NAME", "Test User"},
+    {"GIT_AUTHOR_EMAIL", "test@test.com"},
+    {"GIT_COMMITTER_NAME", "Test User"},
+    {"GIT_COMMITTER_EMAIL", "test@test.com"}
+  ]
+
+  defp setup_repo do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "git_archive_test_#{:erlang.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    cfg = Git.Config.new(working_dir: tmp_dir, env: @env)
+    {:ok, :done} = Git.init(config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.name", set_value: "Test User", config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.email", set_value: "test@test.com", config: cfg)
+
+    # Create some files
+    File.write!(Path.join(tmp_dir, "hello.txt"), "hello world\n")
+    File.mkdir_p!(Path.join(tmp_dir, "lib"))
+    File.write!(Path.join(tmp_dir, "lib/app.ex"), "defmodule App do\nend\n")
+    {:ok, :done} = Git.add(all: true, config: cfg)
+    {:ok, _} = Git.commit("initial commit", config: cfg)
+
+    {tmp_dir, cfg}
+  end
+
+  setup do
+    {tmp_dir, config} = setup_repo()
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+    %{tmp_dir: tmp_dir, config: config}
+  end
+
+  describe "args/1" do
+    test "builds default args" do
+      assert Archive.args(%Archive{}) == ["archive", "HEAD"]
+    end
+
+    test "builds args with format and output" do
+      assert Archive.args(%Archive{format: "zip", output: "out.zip"}) ==
+               ["archive", "--format=zip", "--output=out.zip", "HEAD"]
+    end
+
+    test "builds args with prefix and paths" do
+      assert Archive.args(%Archive{prefix: "project/", paths: ["lib/"]}) ==
+               ["archive", "--prefix=project/", "HEAD", "--", "lib/"]
+    end
+
+    test "builds args with verbose and worktree_attributes" do
+      assert Archive.args(%Archive{verbose: true, worktree_attributes: true}) ==
+               ["archive", "-v", "--worktree-attributes", "HEAD"]
+    end
+
+    test "builds args with remote" do
+      assert Archive.args(%Archive{remote: "origin"}) ==
+               ["archive", "--remote=origin", "HEAD"]
+    end
+
+    test "builds args with custom ref" do
+      assert Archive.args(%Archive{ref: "v1.0"}) ==
+               ["archive", "v1.0"]
+    end
+  end
+
+  describe "git archive" do
+    test "creates a tar archive", %{tmp_dir: tmp_dir, config: config} do
+      output_path = Path.join(tmp_dir, "archive.tar")
+
+      {:ok, :done} =
+        Git.Command.run(Archive, %Archive{output: output_path, format: "tar"}, config)
+
+      assert File.exists?(output_path)
+      assert File.stat!(output_path).size > 0
+    end
+
+    test "creates a zip archive", %{tmp_dir: tmp_dir, config: config} do
+      output_path = Path.join(tmp_dir, "archive.zip")
+
+      {:ok, :done} =
+        Git.Command.run(Archive, %Archive{output: output_path, format: "zip"}, config)
+
+      assert File.exists?(output_path)
+      assert File.stat!(output_path).size > 0
+    end
+
+    test "creates archive with prefix", %{tmp_dir: tmp_dir, config: config} do
+      output_path = Path.join(tmp_dir, "prefixed.tar")
+
+      {:ok, :done} =
+        Git.Command.run(
+          Archive,
+          %Archive{output: output_path, format: "tar", prefix: "myproject/"},
+          config
+        )
+
+      assert File.exists?(output_path)
+
+      # Verify the prefix is present by listing tar contents
+      {tar_output, 0} = System.cmd("tar", ["tf", output_path])
+      assert String.contains?(tar_output, "myproject/")
+    end
+
+    test "creates archive with path filter", %{tmp_dir: tmp_dir, config: config} do
+      output_path = Path.join(tmp_dir, "lib_only.tar")
+
+      {:ok, :done} =
+        Git.Command.run(
+          Archive,
+          %Archive{output: output_path, format: "tar", paths: ["lib/"]},
+          config
+        )
+
+      assert File.exists?(output_path)
+
+      {tar_output, 0} = System.cmd("tar", ["tf", output_path])
+      assert String.contains?(tar_output, "lib/app.ex")
+      refute String.contains?(tar_output, "hello.txt")
+    end
+  end
+end

--- a/test/git/commands/describe_test.exs
+++ b/test/git/commands/describe_test.exs
@@ -1,0 +1,102 @@
+defmodule Git.Commands.DescribeTest do
+  use ExUnit.Case, async: true
+
+  alias Git.Commands.Describe
+  alias Git.Config
+
+  defp setup_repo do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "git_describe_test_#{:erlang.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    cfg = Config.new(working_dir: tmp_dir)
+    {:ok, :done} = Git.init(config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.name", set_value: "Test User", config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.email", set_value: "test@test.com", config: cfg)
+    {:ok, _} = Git.commit("initial", allow_empty: true, config: cfg)
+    {tmp_dir, cfg}
+  end
+
+  setup do
+    {tmp_dir, config} = setup_repo()
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+    %{tmp_dir: tmp_dir, config: config}
+  end
+
+  describe "args/1" do
+    test "default args" do
+      assert Describe.args(%Describe{}) == ["describe"]
+    end
+
+    test "with tags and always" do
+      assert Describe.args(%Describe{tags: true, always: true}) ==
+               ["describe", "--tags", "--always"]
+    end
+
+    test "with abbrev and long" do
+      assert Describe.args(%Describe{abbrev: 4, long: true}) ==
+               ["describe", "--long", "--abbrev=4"]
+    end
+
+    test "with dirty boolean" do
+      assert Describe.args(%Describe{dirty: true}) == ["describe", "--dirty"]
+    end
+
+    test "with dirty mark string" do
+      assert Describe.args(%Describe{dirty: "-modified"}) ==
+               ["describe", "--dirty=-modified"]
+    end
+
+    test "with exact_match and ref" do
+      assert Describe.args(%Describe{exact_match: true, ref: "v1.0"}) ==
+               ["describe", "--exact-match", "v1.0"]
+    end
+
+    test "with match and exclude patterns" do
+      assert Describe.args(%Describe{match: "v*", exclude: "v0.*"}) ==
+               ["describe", "--match=v*", "--exclude=v0.*"]
+    end
+
+    test "with first_parent and candidates" do
+      assert Describe.args(%Describe{first_parent: true, candidates: 5}) ==
+               ["describe", "--first-parent", "--candidates=5"]
+    end
+
+    test "with broken" do
+      assert Describe.args(%Describe{broken: true}) == ["describe", "--broken"]
+    end
+  end
+
+  describe "describe with tags" do
+    test "describes a tagged commit", %{tmp_dir: tmp_dir, config: config} do
+      System.cmd("git", ["tag", "v1.0"], cd: tmp_dir)
+
+      assert {:ok, "v1.0"} = Git.describe(tags: true, config: config)
+    end
+
+    test "describes a commit after a tag", %{tmp_dir: tmp_dir, config: config} do
+      System.cmd("git", ["tag", "v1.0"], cd: tmp_dir)
+      {:ok, _} = Git.commit("second", allow_empty: true, config: config)
+
+      {:ok, description} = Git.describe(tags: true, config: config)
+      assert String.starts_with?(description, "v1.0-1-g")
+    end
+  end
+
+  describe "describe with --always" do
+    test "returns abbreviated hash when no tags exist", %{config: config} do
+      {:ok, description} = Git.describe(always: true, config: config)
+      assert String.length(description) > 0
+      assert Regex.match?(~r/^[0-9a-f]+$/, description)
+    end
+  end
+
+  describe "exact-match failure" do
+    test "returns error when no tag matches exactly", %{config: config} do
+      assert {:error, {_output, 128}} = Git.describe(exact_match: true, config: config)
+    end
+  end
+end

--- a/test/git/commands/format_patch_test.exs
+++ b/test/git/commands/format_patch_test.exs
@@ -1,0 +1,115 @@
+defmodule Git.Commands.FormatPatchTest do
+  use ExUnit.Case, async: true
+
+  alias Git.Commands.FormatPatch
+  alias Git.Config
+
+  defp setup_repo do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "git_format_patch_test_#{:erlang.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    cfg = Config.new(working_dir: tmp_dir)
+    {:ok, :done} = Git.init(config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.name", set_value: "Test User", config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.email", set_value: "test@test.com", config: cfg)
+    {:ok, _} = Git.commit("initial", allow_empty: true, config: cfg)
+
+    file_path = Path.join(tmp_dir, "hello.txt")
+    File.write!(file_path, "hello world\n")
+    System.cmd("git", ["add", "hello.txt"], cd: tmp_dir)
+    {:ok, _} = Git.commit("add hello", config: cfg)
+
+    {tmp_dir, cfg}
+  end
+
+  setup do
+    {tmp_dir, config} = setup_repo()
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+    %{tmp_dir: tmp_dir, config: config}
+  end
+
+  describe "args/1" do
+    test "default args" do
+      assert FormatPatch.args(%FormatPatch{ref: "HEAD~3"}) ==
+               ["format-patch", "HEAD~3"]
+    end
+
+    test "with stdout" do
+      assert FormatPatch.args(%FormatPatch{ref: "HEAD~1", stdout: true}) ==
+               ["format-patch", "--stdout", "HEAD~1"]
+    end
+
+    test "with output_directory and numbered" do
+      assert FormatPatch.args(%FormatPatch{
+               ref: "v1.0..v2.0",
+               output_directory: "/tmp/patches",
+               numbered: true
+             }) ==
+               ["format-patch", "-n", "-o", "/tmp/patches", "v1.0..v2.0"]
+    end
+
+    test "with cover_letter and subject_prefix" do
+      assert FormatPatch.args(%FormatPatch{
+               ref: "HEAD~2",
+               cover_letter: true,
+               subject_prefix: "RFC"
+             }) ==
+               ["format-patch", "--cover-letter", "--subject-prefix=RFC", "HEAD~2"]
+    end
+
+    test "with no_stat and no_signature" do
+      assert FormatPatch.args(%FormatPatch{ref: "HEAD~1", no_stat: true, no_signature: true}) ==
+               ["format-patch", "--no-stat", "--no-signature", "HEAD~1"]
+    end
+
+    test "with start_number and signature" do
+      assert FormatPatch.args(%FormatPatch{
+               ref: "HEAD~1",
+               start_number: 5,
+               signature: "My Project"
+             }) ==
+               ["format-patch", "--start-number=5", "--signature=My Project", "HEAD~1"]
+    end
+
+    test "with quiet and zero_commit" do
+      assert FormatPatch.args(%FormatPatch{ref: "HEAD~1", quiet: true, zero_commit: true}) ==
+               ["format-patch", "-q", "--zero-commit", "HEAD~1"]
+    end
+
+    test "with from and base" do
+      assert FormatPatch.args(%FormatPatch{ref: "HEAD~1", from: "Author", base: "main"}) ==
+               ["format-patch", "--from=Author", "--base=main", "HEAD~1"]
+    end
+  end
+
+  describe "generate patches to directory" do
+    test "creates patch files in output directory", %{tmp_dir: tmp_dir, config: config} do
+      patch_dir = Path.join(tmp_dir, "patches")
+      File.mkdir_p!(patch_dir)
+
+      {:ok, files} =
+        Git.format_patch(ref: "HEAD~1", output_directory: patch_dir, config: config)
+
+      assert is_list(files)
+      assert length(files) == 1
+
+      patch_file = hd(files)
+      assert String.ends_with?(patch_file, ".patch")
+      assert File.exists?(patch_file)
+    end
+  end
+
+  describe "stdout mode" do
+    test "returns patch content as string", %{config: config} do
+      {:ok, content} = Git.format_patch(ref: "HEAD~1", stdout: true, config: config)
+
+      assert is_binary(content)
+      assert String.contains?(content, "add hello")
+      assert String.contains?(content, "hello world")
+    end
+  end
+end

--- a/test/git/commands/ls_remote_test.exs
+++ b/test/git/commands/ls_remote_test.exs
@@ -1,0 +1,150 @@
+defmodule Git.LsRemoteTest do
+  use ExUnit.Case, async: true
+
+  alias Git.Commands.LsRemote
+  alias Git.Config
+  alias Git.LsRemoteEntry
+
+  @env [
+    {"GIT_AUTHOR_NAME", "Test User"},
+    {"GIT_AUTHOR_EMAIL", "test@test.com"},
+    {"GIT_COMMITTER_NAME", "Test User"},
+    {"GIT_COMMITTER_EMAIL", "test@test.com"}
+  ]
+
+  defp setup_repo_with_remote do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "git_ls_remote_test_#{:erlang.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    local_dir = Path.join(tmp_dir, "local")
+    remote_dir = Path.join(tmp_dir, "remote.git")
+    File.mkdir_p!(local_dir)
+    File.mkdir_p!(remote_dir)
+
+    # Create bare remote
+    System.cmd("git", ["init", "--bare", "--initial-branch=main"], cd: remote_dir)
+
+    # Set up local repo
+    cfg = Config.new(working_dir: local_dir, env: @env)
+    {:ok, :done} = Git.init(config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.name", set_value: "Test User", config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.email", set_value: "test@test.com", config: cfg)
+
+    # Create initial commit
+    File.write!(Path.join(local_dir, "README.md"), "# Test\n")
+    {:ok, :done} = Git.add(all: true, config: cfg)
+    {:ok, _} = Git.commit("initial commit", config: cfg)
+
+    # Add remote and push
+    {:ok, :done} = Git.remote(add_name: "origin", add_url: remote_dir, config: cfg)
+    {:ok, :done} = Git.push(remote: "origin", branch: "main", set_upstream: true, config: cfg)
+
+    # Create a tag and push it
+    {:ok, :done} = Git.tag(create: "v1.0.0", message: "release v1.0.0", config: cfg)
+    System.cmd("git", ["push", "origin", "v1.0.0"], cd: local_dir, env: @env)
+
+    {tmp_dir, local_dir, remote_dir, cfg}
+  end
+
+  setup do
+    {tmp_dir, local_dir, remote_dir, config} = setup_repo_with_remote()
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+    %{tmp_dir: tmp_dir, local_dir: local_dir, remote_dir: remote_dir, config: config}
+  end
+
+  describe "args/1" do
+    test "builds default args" do
+      assert LsRemote.args(%LsRemote{}) == ["ls-remote"]
+    end
+
+    test "builds args with heads and tags" do
+      assert LsRemote.args(%LsRemote{heads: true, tags: true}) ==
+               ["ls-remote", "--heads", "--tags"]
+    end
+
+    test "builds args with remote and refs" do
+      assert LsRemote.args(%LsRemote{remote: "origin", refs: "refs/heads/main"}) ==
+               ["ls-remote", "origin", "refs/heads/main"]
+    end
+
+    test "builds args with symref and sort" do
+      assert LsRemote.args(%LsRemote{symref: true, sort: "version:refname"}) ==
+               ["ls-remote", "--symref", "--sort=version:refname"]
+    end
+
+    test "builds args with quiet" do
+      assert LsRemote.args(%LsRemote{quiet: true}) ==
+               ["ls-remote", "-q"]
+    end
+
+    test "builds args with exit_code" do
+      assert LsRemote.args(%LsRemote{exit_code: true}) ==
+               ["ls-remote", "--exit-code"]
+    end
+  end
+
+  describe "git ls-remote" do
+    test "lists refs from remote", %{remote_dir: remote_dir, config: config} do
+      {:ok, entries} =
+        Git.Command.run(LsRemote, %LsRemote{remote: remote_dir}, config)
+
+      assert is_list(entries)
+      assert entries != []
+
+      Enum.each(entries, fn entry ->
+        assert %LsRemoteEntry{} = entry
+      end)
+
+      # Should have at least HEAD and refs/heads/main
+      refs = Enum.map(entries, & &1.ref)
+      assert "HEAD" in refs
+      assert "refs/heads/main" in refs
+    end
+
+    test "filters heads only", %{remote_dir: remote_dir, config: config} do
+      {:ok, entries} =
+        Git.Command.run(LsRemote, %LsRemote{remote: remote_dir, heads: true}, config)
+
+      refs = Enum.map(entries, & &1.ref)
+      assert Enum.all?(refs, &String.starts_with?(&1, "refs/heads/"))
+    end
+
+    test "filters tags only", %{remote_dir: remote_dir, config: config} do
+      {:ok, entries} =
+        Git.Command.run(LsRemote, %LsRemote{remote: remote_dir, tags: true}, config)
+
+      refs = Enum.map(entries, & &1.ref)
+      assert Enum.all?(refs, &String.starts_with?(&1, "refs/tags/"))
+      assert Enum.any?(refs, &(&1 == "refs/tags/v1.0.0"))
+    end
+
+    test "entries have valid SHAs", %{remote_dir: remote_dir, config: config} do
+      {:ok, entries} =
+        Git.Command.run(LsRemote, %LsRemote{remote: remote_dir}, config)
+
+      sha_entries = Enum.filter(entries, & &1.sha)
+
+      Enum.each(sha_entries, fn entry ->
+        assert String.match?(entry.sha, ~r/^[0-9a-f]{40}$/)
+      end)
+    end
+
+    test "exit_code 2 returns empty list for no matching refs", %{
+      remote_dir: remote_dir,
+      config: config
+    } do
+      {:ok, entries} =
+        Git.Command.run(
+          LsRemote,
+          %LsRemote{remote: remote_dir, exit_code: true, refs: "refs/heads/nonexistent"},
+          config
+        )
+
+      assert entries == []
+    end
+  end
+end

--- a/test/git/commands/ls_tree_test.exs
+++ b/test/git/commands/ls_tree_test.exs
@@ -1,0 +1,181 @@
+defmodule Git.LsTreeTest do
+  use ExUnit.Case, async: true
+
+  alias Git.Commands.LsTree
+  alias Git.Config
+  alias Git.TreeEntry
+
+  @env [
+    {"GIT_AUTHOR_NAME", "Test User"},
+    {"GIT_AUTHOR_EMAIL", "test@test.com"},
+    {"GIT_COMMITTER_NAME", "Test User"},
+    {"GIT_COMMITTER_EMAIL", "test@test.com"}
+  ]
+
+  defp setup_repo do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "git_ls_tree_test_#{:erlang.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    cfg = Config.new(working_dir: tmp_dir, env: @env)
+    {:ok, :done} = Git.init(config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.name", set_value: "Test User", config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.email", set_value: "test@test.com", config: cfg)
+
+    # Create files and directories
+    File.write!(Path.join(tmp_dir, "README.md"), "# Test Project\n")
+    File.write!(Path.join(tmp_dir, "mix.exs"), "defmodule Mix do\nend\n")
+    File.mkdir_p!(Path.join(tmp_dir, "lib"))
+    File.write!(Path.join(tmp_dir, "lib/app.ex"), "defmodule App do\nend\n")
+    File.mkdir_p!(Path.join(tmp_dir, "lib/sub"))
+    File.write!(Path.join(tmp_dir, "lib/sub/nested.ex"), "defmodule Nested do\nend\n")
+    {:ok, :done} = Git.add(all: true, config: cfg)
+    {:ok, _} = Git.commit("initial commit", config: cfg)
+
+    {tmp_dir, cfg}
+  end
+
+  setup do
+    {tmp_dir, config} = setup_repo()
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+    %{tmp_dir: tmp_dir, config: config}
+  end
+
+  describe "args/1" do
+    test "builds default args" do
+      assert LsTree.args(%LsTree{}) == ["ls-tree", "HEAD"]
+    end
+
+    test "builds args with recursive and long" do
+      assert LsTree.args(%LsTree{recursive: true, long: true}) ==
+               ["ls-tree", "-r", "-l", "HEAD"]
+    end
+
+    test "builds args with name_only and custom ref" do
+      assert LsTree.args(%LsTree{name_only: true, ref: "main"}) ==
+               ["ls-tree", "--name-only", "main"]
+    end
+
+    test "builds args with path filter" do
+      assert LsTree.args(%LsTree{path: "lib/"}) ==
+               ["ls-tree", "HEAD", "--", "lib/"]
+    end
+
+    test "builds args with abbrev" do
+      assert LsTree.args(%LsTree{abbrev: 8}) ==
+               ["ls-tree", "--abbrev=8", "HEAD"]
+    end
+
+    test "builds args with tree_only" do
+      assert LsTree.args(%LsTree{tree_only: true}) ==
+               ["ls-tree", "-d", "HEAD"]
+    end
+
+    test "builds args with full_name and full_tree" do
+      assert LsTree.args(%LsTree{full_name: true, full_tree: true}) ==
+               ["ls-tree", "--full-name", "--full-tree", "HEAD"]
+    end
+  end
+
+  describe "git ls-tree" do
+    test "lists files at HEAD", %{config: config} do
+      {:ok, entries} =
+        Git.Command.run(LsTree, %LsTree{}, config)
+
+      assert is_list(entries)
+      assert entries != []
+
+      paths = Enum.map(entries, & &1.path)
+      assert "README.md" in paths
+      assert "mix.exs" in paths
+      assert "lib" in paths
+
+      Enum.each(entries, fn entry ->
+        assert %TreeEntry{} = entry
+        assert entry.mode in ["100644", "040000"]
+        assert entry.type in [:blob, :tree]
+        assert String.match?(entry.sha, ~r/^[0-9a-f]+$/)
+      end)
+    end
+
+    test "recursive lists all files", %{config: config} do
+      {:ok, entries} =
+        Git.Command.run(LsTree, %LsTree{recursive: true}, config)
+
+      paths = Enum.map(entries, & &1.path)
+      assert "README.md" in paths
+      assert "mix.exs" in paths
+      assert "lib/app.ex" in paths
+      assert "lib/sub/nested.ex" in paths
+
+      # With recursive, all entries should be blobs (trees are expanded)
+      Enum.each(entries, fn entry ->
+        assert entry.type == :blob
+      end)
+    end
+
+    test "name_only returns strings", %{config: config} do
+      {:ok, entries} =
+        Git.Command.run(LsTree, %LsTree{name_only: true}, config)
+
+      assert is_list(entries)
+      assert Enum.all?(entries, &is_binary/1)
+      assert "README.md" in entries
+      assert "lib" in entries
+    end
+
+    test "long format includes sizes", %{config: config} do
+      {:ok, entries} =
+        Git.Command.run(LsTree, %LsTree{recursive: true, long: true}, config)
+
+      blob_entries = Enum.filter(entries, &(&1.type == :blob))
+
+      Enum.each(blob_entries, fn entry ->
+        assert is_integer(entry.size)
+        assert entry.size > 0
+      end)
+    end
+
+    test "tree_only shows only directories", %{config: config} do
+      {:ok, entries} =
+        Git.Command.run(LsTree, %LsTree{tree_only: true}, config)
+
+      Enum.each(entries, fn entry ->
+        assert entry.type == :tree
+        assert entry.mode == "040000"
+      end)
+
+      paths = Enum.map(entries, & &1.path)
+      assert "lib" in paths
+    end
+
+    test "path filter restricts output", %{config: config} do
+      {:ok, entries} =
+        Git.Command.run(LsTree, %LsTree{path: "lib"}, config)
+
+      paths = Enum.map(entries, & &1.path)
+      # ls-tree HEAD -- lib shows the "lib" tree entry itself
+      assert paths == ["lib"]
+
+      # Use trailing slash to see contents of the directory
+      {:ok, contents} =
+        Git.Command.run(LsTree, %LsTree{path: "lib/"}, config)
+
+      content_paths = Enum.map(contents, & &1.path)
+      assert "lib/app.ex" in content_paths
+      assert "lib/sub" in content_paths
+    end
+  end
+
+  describe "git ls-tree failure" do
+    test "returns error for invalid ref", %{config: config} do
+      assert {:error, {_output, exit_code}} =
+               Git.Command.run(LsTree, %LsTree{ref: "nonexistent-ref"}, config)
+
+      assert exit_code != 0
+    end
+  end
+end

--- a/test/git/commands/shortlog_test.exs
+++ b/test/git/commands/shortlog_test.exs
@@ -1,0 +1,164 @@
+defmodule Git.Commands.ShortlogTest do
+  use ExUnit.Case, async: true
+
+  alias Git.Commands.Shortlog
+  alias Git.Config
+  alias Git.ShortlogEntry
+
+  defp setup_repo do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "git_shortlog_test_#{:erlang.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    cfg = Config.new(working_dir: tmp_dir)
+    {:ok, :done} = Git.init(config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.name", set_value: "Test User", config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.email", set_value: "test@test.com", config: cfg)
+    {:ok, _} = Git.commit("initial commit", allow_empty: true, config: cfg)
+    {:ok, _} = Git.commit("second commit", allow_empty: true, config: cfg)
+    {:ok, _} = Git.commit("third commit", allow_empty: true, config: cfg)
+    {tmp_dir, cfg}
+  end
+
+  setup do
+    {tmp_dir, config} = setup_repo()
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+    %{tmp_dir: tmp_dir, config: config}
+  end
+
+  describe "args/1" do
+    test "default args" do
+      assert Shortlog.args(%Shortlog{}) == ["shortlog"]
+    end
+
+    test "summary and numbered" do
+      assert Shortlog.args(%Shortlog{summary: true, numbered: true}) ==
+               ["shortlog", "-s", "-n"]
+    end
+
+    test "with email and ref" do
+      assert Shortlog.args(%Shortlog{email: true, ref: "v1.0..HEAD"}) ==
+               ["shortlog", "-e", "v1.0..HEAD"]
+    end
+
+    test "with max_count and group" do
+      assert Shortlog.args(%Shortlog{max_count: 10, group: "author"}) ==
+               ["shortlog", "--max-count=10", "--group=author"]
+    end
+
+    test "with since and until_date" do
+      assert Shortlog.args(%Shortlog{since: "2024-01-01", until_date: "2024-12-31"}) ==
+               ["shortlog", "--since=2024-01-01", "--until=2024-12-31"]
+    end
+
+    test "with all" do
+      assert Shortlog.args(%Shortlog{all: true}) == ["shortlog", "--all"]
+    end
+  end
+
+  describe "summary mode" do
+    test "returns shortlog entries with counts", %{config: config} do
+      {:ok, [entry | _]} = Git.shortlog(summary: true, numbered: true, all: true, config: config)
+      assert %ShortlogEntry{} = entry
+      assert entry.author == "Test User"
+      assert entry.count == 3
+      assert entry.commits == []
+    end
+  end
+
+  describe "full mode with commits" do
+    test "returns entries with commit subjects", %{config: config} do
+      {:ok, [entry | _]} = Git.shortlog(all: true, config: config)
+      assert %ShortlogEntry{} = entry
+      assert entry.author == "Test User"
+      assert entry.count == 3
+      assert length(entry.commits) == 3
+      assert "initial commit" in entry.commits
+      assert "second commit" in entry.commits
+      assert "third commit" in entry.commits
+    end
+  end
+
+  describe "email mode" do
+    test "returns entries with email addresses", %{config: config} do
+      {:ok, [entry | _]} =
+        Git.shortlog(summary: true, email: true, all: true, config: config)
+
+      assert entry.email == "test@test.com"
+    end
+  end
+
+  describe "ref range" do
+    test "limits output to ref range", %{tmp_dir: tmp_dir, config: config} do
+      System.cmd("git", ["tag", "v1.0", "HEAD~1"], cd: tmp_dir)
+
+      {:ok, entries} =
+        Git.shortlog(summary: true, all: true, ref: "v1.0..HEAD", config: config)
+
+      assert is_list(entries)
+
+      case entries do
+        [_ | _] ->
+          total = Enum.reduce(entries, 0, fn e, acc -> acc + e.count end)
+          assert total == 1
+
+        [] ->
+          :ok
+      end
+    end
+  end
+
+  describe "ShortlogEntry.parse_summary/1" do
+    test "parses summary lines" do
+      output = "     3\tAlice\n     1\tBob\n"
+
+      entries = ShortlogEntry.parse_summary(output)
+      assert length(entries) == 2
+      assert hd(entries).author == "Alice"
+      assert hd(entries).count == 3
+    end
+
+    test "parses summary lines with email" do
+      output = "     2\tAlice <alice@example.com>\n"
+
+      entries = ShortlogEntry.parse_summary(output)
+      assert length(entries) == 1
+      assert hd(entries).author == "Alice"
+      assert hd(entries).email == "alice@example.com"
+      assert hd(entries).count == 2
+    end
+
+    test "parses empty output" do
+      assert ShortlogEntry.parse_summary("") == []
+    end
+  end
+
+  describe "ShortlogEntry.parse_full/1" do
+    test "parses full output with commits" do
+      output = """
+      Alice (2):
+            first commit
+            second commit
+
+      Bob (1):
+            only commit
+
+      """
+
+      entries = ShortlogEntry.parse_full(output)
+      assert length(entries) == 2
+
+      alice = Enum.find(entries, &(&1.author == "Alice"))
+      assert alice.count == 2
+      assert length(alice.commits) == 2
+      assert "first commit" in alice.commits
+
+      bob = Enum.find(entries, &(&1.author == "Bob"))
+      assert bob.count == 1
+      assert ["only commit"] == bob.commits
+    end
+  end
+end

--- a/test/git/commands/submodule_test.exs
+++ b/test/git/commands/submodule_test.exs
@@ -1,0 +1,358 @@
+defmodule Git.SubmoduleTest do
+  use ExUnit.Case, async: true
+
+  alias Git.Commands.Submodule, as: SubmoduleCmd
+  alias Git.{Config, SubmoduleEntry}
+
+  # Environment variables to allow the file:// transport protocol in newer
+  # git versions (>= 2.38) and set committer identity for tests.
+  @test_env [
+    {"GIT_CONFIG_COUNT", "1"},
+    {"GIT_CONFIG_KEY_0", "protocol.file.allow"},
+    {"GIT_CONFIG_VALUE_0", "always"},
+    {"GIT_AUTHOR_NAME", "Test User"},
+    {"GIT_AUTHOR_EMAIL", "test@test.com"},
+    {"GIT_COMMITTER_NAME", "Test User"},
+    {"GIT_COMMITTER_EMAIL", "test@test.com"}
+  ]
+
+  defp setup_repos(name) do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "git_submodule_#{name}_#{:erlang.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+
+    # Create the "library" repo to use as submodule source
+    lib_dir = Path.join(tmp_dir, "library")
+    File.mkdir_p!(lib_dir)
+    lib_cfg = Config.new(working_dir: lib_dir, env: @test_env)
+    {:ok, :done} = Git.init(config: lib_cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.name", set_value: "Test User", config: lib_cfg)
+
+    {:ok, :done} =
+      Git.git_config(set_key: "user.email", set_value: "test@test.com", config: lib_cfg)
+
+    File.write!(Path.join(lib_dir, "lib.txt"), "library content\n")
+    {:ok, :done} = Git.add(all: true, config: lib_cfg)
+    {:ok, _} = Git.commit("initial library commit", config: lib_cfg)
+
+    # Create the "project" repo
+    project_dir = Path.join(tmp_dir, "project")
+    File.mkdir_p!(project_dir)
+    proj_cfg = Config.new(working_dir: project_dir, env: @test_env)
+    {:ok, :done} = Git.init(config: proj_cfg)
+
+    {:ok, :done} =
+      Git.git_config(set_key: "user.name", set_value: "Test User", config: proj_cfg)
+
+    {:ok, :done} =
+      Git.git_config(set_key: "user.email", set_value: "test@test.com", config: proj_cfg)
+
+    {:ok, _} = Git.commit("initial project commit", allow_empty: true, config: proj_cfg)
+
+    {tmp_dir, lib_dir, project_dir, proj_cfg}
+  end
+
+  describe "args/1" do
+    test "default status mode" do
+      assert SubmoduleCmd.args(%SubmoduleCmd{}) == ["submodule", "status"]
+    end
+
+    test "status with recursive" do
+      cmd = %SubmoduleCmd{recursive: true}
+      assert SubmoduleCmd.args(cmd) == ["submodule", "status", "--recursive"]
+    end
+
+    test "status with path" do
+      cmd = %SubmoduleCmd{path: "vendor/lib"}
+      assert SubmoduleCmd.args(cmd) == ["submodule", "status", "vendor/lib"]
+    end
+
+    test "init mode" do
+      cmd = %SubmoduleCmd{init: true}
+      assert SubmoduleCmd.args(cmd) == ["submodule", "init"]
+    end
+
+    test "init with path" do
+      cmd = %SubmoduleCmd{init: true, path: "vendor/lib"}
+      assert SubmoduleCmd.args(cmd) == ["submodule", "init", "vendor/lib"]
+    end
+
+    test "update mode" do
+      cmd = %SubmoduleCmd{update: true}
+      assert SubmoduleCmd.args(cmd) == ["submodule", "update"]
+    end
+
+    test "update with all flags" do
+      cmd = %SubmoduleCmd{
+        update: true,
+        force: true,
+        remote: true,
+        merge: true,
+        rebase: true,
+        recursive: true,
+        depth: 1,
+        reference: "/tmp/ref"
+      }
+
+      assert SubmoduleCmd.args(cmd) == [
+               "submodule",
+               "update",
+               "--force",
+               "--remote",
+               "--merge",
+               "--rebase",
+               "--recursive",
+               "--depth",
+               "1",
+               "--reference",
+               "/tmp/ref"
+             ]
+    end
+
+    test "add mode with url only" do
+      cmd = %SubmoduleCmd{add_url: "https://example.com/lib.git"}
+      assert SubmoduleCmd.args(cmd) == ["submodule", "add", "https://example.com/lib.git"]
+    end
+
+    test "add mode with url and path" do
+      cmd = %SubmoduleCmd{add_url: "https://example.com/lib.git", add_path: "vendor/lib"}
+
+      assert SubmoduleCmd.args(cmd) == [
+               "submodule",
+               "add",
+               "https://example.com/lib.git",
+               "vendor/lib"
+             ]
+    end
+
+    test "add mode with branch and name" do
+      cmd = %SubmoduleCmd{
+        add_url: "https://example.com/lib.git",
+        add_path: "vendor/lib",
+        branch: "develop",
+        name: "mylib"
+      }
+
+      assert SubmoduleCmd.args(cmd) == [
+               "submodule",
+               "add",
+               "--name",
+               "mylib",
+               "-b",
+               "develop",
+               "https://example.com/lib.git",
+               "vendor/lib"
+             ]
+    end
+
+    test "deinit mode" do
+      cmd = %SubmoduleCmd{deinit: "vendor/lib"}
+      assert SubmoduleCmd.args(cmd) == ["submodule", "deinit", "vendor/lib"]
+    end
+
+    test "deinit with force" do
+      cmd = %SubmoduleCmd{deinit: "vendor/lib", force: true}
+      assert SubmoduleCmd.args(cmd) == ["submodule", "deinit", "--force", "vendor/lib"]
+    end
+
+    test "sync mode" do
+      cmd = %SubmoduleCmd{sync: true}
+      assert SubmoduleCmd.args(cmd) == ["submodule", "sync"]
+    end
+
+    test "sync with recursive" do
+      cmd = %SubmoduleCmd{sync: true, recursive: true}
+      assert SubmoduleCmd.args(cmd) == ["submodule", "sync", "--recursive"]
+    end
+
+    test "summary mode" do
+      cmd = %SubmoduleCmd{summary: true}
+      assert SubmoduleCmd.args(cmd) == ["submodule", "summary"]
+    end
+
+    test "set-branch mode" do
+      cmd = %SubmoduleCmd{set_branch: "develop", path: "vendor/lib"}
+      assert SubmoduleCmd.args(cmd) == ["submodule", "set-branch", "-b", "develop", "vendor/lib"]
+    end
+
+    test "set-url mode" do
+      cmd = %SubmoduleCmd{set_url: "https://new.example.com/lib.git", path: "vendor/lib"}
+
+      assert SubmoduleCmd.args(cmd) == [
+               "submodule",
+               "set-url",
+               "vendor/lib",
+               "https://new.example.com/lib.git"
+             ]
+    end
+  end
+
+  describe "SubmoduleEntry.parse/1" do
+    test "parses current status line" do
+      output = " abc1234def5678 lib/sub (v1.0.0)\n"
+      [entry] = SubmoduleEntry.parse(output)
+
+      assert %SubmoduleEntry{
+               sha: "abc1234def5678",
+               path: "lib/sub",
+               describe: "v1.0.0",
+               status: :current
+             } = entry
+    end
+
+    test "parses modified status line" do
+      output = "+def5678abc1234 vendor/dep\n"
+      [entry] = SubmoduleEntry.parse(output)
+
+      assert %SubmoduleEntry{
+               sha: "def5678abc1234",
+               path: "vendor/dep",
+               describe: nil,
+               status: :modified
+             } = entry
+    end
+
+    test "parses uninitialized status line" do
+      output = "-aaa1111bbb2222 lib/uninit\n"
+      [entry] = SubmoduleEntry.parse(output)
+
+      assert %SubmoduleEntry{
+               sha: "aaa1111bbb2222",
+               path: "lib/uninit",
+               describe: nil,
+               status: :uninitialized
+             } = entry
+    end
+
+    test "parses conflict status line" do
+      output = "Uccc3333ddd4444 lib/conflict (v2.0)\n"
+      [entry] = SubmoduleEntry.parse(output)
+
+      assert %SubmoduleEntry{
+               sha: "ccc3333ddd4444",
+               path: "lib/conflict",
+               describe: "v2.0",
+               status: :conflict
+             } = entry
+    end
+
+    test "parses multiple entries" do
+      output = """
+       abc1234 path/a (v1.0)
+      +def5678 path/b
+      -111aaaa path/c
+      """
+
+      entries = SubmoduleEntry.parse(output)
+      assert length(entries) == 3
+      assert Enum.map(entries, & &1.status) == [:current, :modified, :uninitialized]
+    end
+
+    test "parses empty output" do
+      assert SubmoduleEntry.parse("") == []
+    end
+  end
+
+  describe "status on repo with no submodules" do
+    test "returns empty list" do
+      {tmp_dir, _lib_dir, _project_dir, proj_cfg} = setup_repos("empty_status")
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      assert {:ok, []} = Git.submodule(config: proj_cfg)
+    end
+  end
+
+  describe "add and status" do
+    test "adds a submodule and shows it in status" do
+      {tmp_dir, lib_dir, _project_dir, proj_cfg} = setup_repos("add_status")
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      # Add the library as a submodule
+      assert {:ok, :done} =
+               Git.submodule(add_url: lib_dir, add_path: "vendor/library", config: proj_cfg)
+
+      # Status should show the submodule
+      assert {:ok, entries} = Git.submodule(config: proj_cfg)
+      assert length(entries) == 1
+
+      [entry] = entries
+      assert entry.path == "vendor/library"
+      assert entry.sha != ""
+    end
+  end
+
+  describe "init and update" do
+    test "initializes and updates submodules" do
+      {tmp_dir, lib_dir, project_dir, proj_cfg} = setup_repos("init_update")
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      # Add submodule and commit
+      assert {:ok, :done} =
+               Git.submodule(add_url: lib_dir, add_path: "vendor/library", config: proj_cfg)
+
+      {:ok, :done} = Git.add(all: true, config: proj_cfg)
+      {:ok, _} = Git.commit("add submodule", config: proj_cfg)
+
+      # Clone the project to simulate a fresh checkout
+      clone_dir = Path.join(tmp_dir, "clone")
+      File.mkdir_p!(clone_dir)
+
+      System.cmd("git", ["clone", project_dir, clone_dir], env: @test_env)
+
+      clone_cfg = Config.new(working_dir: clone_dir, env: @test_env)
+
+      # Submodule should be uninitialized in the clone
+      assert {:ok, entries} = Git.submodule(config: clone_cfg)
+      assert length(entries) == 1
+      assert hd(entries).status == :uninitialized
+
+      # Init the submodule
+      assert {:ok, :done} = Git.submodule(init: true, config: clone_cfg)
+
+      # Update the submodule
+      assert {:ok, :done} = Git.submodule(update: true, config: clone_cfg)
+
+      # Now check that the submodule file exists
+      assert File.exists?(Path.join(clone_dir, "vendor/library/lib.txt"))
+    end
+  end
+
+  describe "deinit" do
+    test "deinitializes a submodule" do
+      {tmp_dir, lib_dir, _project_dir, proj_cfg} = setup_repos("deinit")
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      # Add submodule and commit
+      assert {:ok, :done} =
+               Git.submodule(add_url: lib_dir, add_path: "vendor/library", config: proj_cfg)
+
+      {:ok, :done} = Git.add(all: true, config: proj_cfg)
+      {:ok, _} = Git.commit("add submodule", config: proj_cfg)
+
+      # Deinit the submodule
+      assert {:ok, :done} =
+               Git.submodule(deinit: "vendor/library", force: true, config: proj_cfg)
+    end
+  end
+
+  describe "sync" do
+    test "syncs submodule URLs" do
+      {tmp_dir, lib_dir, _project_dir, proj_cfg} = setup_repos("sync")
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      # Add submodule and commit
+      assert {:ok, :done} =
+               Git.submodule(add_url: lib_dir, add_path: "vendor/library", config: proj_cfg)
+
+      {:ok, :done} = Git.add(all: true, config: proj_cfg)
+      {:ok, _} = Git.commit("add submodule", config: proj_cfg)
+
+      # Sync should succeed
+      assert {:ok, :done} = Git.submodule(sync: true, config: proj_cfg)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

7 new commands bringing the total to 39:

- **describe** - human-readable names from commits (versioning/release tooling)
- **shortlog** - contributor stats with `ShortlogEntry` struct
- **format-patch** - generate patch files for email/review workflows
- **archive** - create tar/zip archives from repo content
- **ls-remote** - list remote refs with `LsRemoteEntry` struct
- **ls-tree** - browse tree objects at any ref with `TreeEntry` struct
- **submodule** - full lifecycle (add, init, update, status, deinit, sync) with `SubmoduleEntry` struct

## Test plan

- [x] `mix format --check-formatted` passes
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix credo --strict` -- 0 issues
- [x] `mix test` -- 746 tests, 0 failures

Closes #33, #34, #35, #36, #37, #38, #39