### PR TITLE
feat: add 8 tier-2 commands (rev-list, merge-base, cherry, cat-file, check-ignore, notes, range-diff, sparse-checkout)

### DIFF
--- a/lib/git.ex
+++ b/lib/git.ex
@@ -1229,4 +1229,272 @@ defmodule Git do
     command = struct!(Git.Commands.LsTree, rest)
     Git.Command.run(Git.Commands.LsTree, command, config)
   end
+
+  @doc """
+  Runs `git rev-list` to list commit objects.
+
+  Returns a list of SHAs by default. With `count: true` returns an integer.
+  With `left_right: true` and `count: true` returns a map with `:left` and
+  `:right` counts.
+
+  ## Options
+
+    * `:config` - a `Git.Config` struct (default: `Git.Config.new()`)
+    * `:ref` - rev range (e.g. `"HEAD"`, `"main..feature"`)
+    * `:max_count` - limit number of commits (`--max-count=N`)
+    * `:skip` - skip N commits (`--skip=N`)
+    * `:count` - output a count instead of SHAs (`--count`)
+    * `:left_right` - mark which side of a symmetric diff (`--left-right`)
+    * `:ancestry_path` - only show commits on the ancestry path (`--ancestry-path`)
+    * `:first_parent` - follow only first parent (`--first-parent`)
+    * `:merges` - only show merge commits (`--merges`)
+    * `:no_merges` - exclude merge commits (`--no-merges`)
+    * `:reverse` - reverse output order (`--reverse`)
+    * `:since` - show commits after date (`--since=`)
+    * `:until_date` - show commits before date (`--until=`)
+    * `:author` - filter by author (`--author=`)
+    * `:all` - list objects from all refs (`--all`)
+    * `:objects` - list objects, not just commits (`--objects`)
+    * `:no_walk` - do not traverse ancestors (`--no-walk`)
+
+  ## Examples
+
+      Git.rev_list(ref: "HEAD", max_count: 10)
+      Git.rev_list(ref: "main..feature", count: true)
+      Git.rev_list(ref: "main...feature", left_right: true, count: true)
+
+  """
+  @spec rev_list(keyword()) ::
+          {:ok, [String.t()] | integer() | map()} | {:error, term()}
+  def rev_list(opts \\ []) do
+    {config, rest} = Keyword.pop(opts, :config, Config.new())
+    command = struct!(Git.Commands.RevList, rest)
+    Git.Command.run(Git.Commands.RevList, command, config)
+  end
+
+  @doc """
+  Runs `git merge-base` to find the best common ancestor(s).
+
+  By default returns a single ancestor SHA. With `is_ancestor: true`,
+  returns a boolean indicating whether the first commit is an ancestor
+  of the second. With `all: true` or `independent: true`, returns a
+  list of SHAs.
+
+  ## Options
+
+    * `:config` - a `Git.Config` struct (default: `Git.Config.new()`)
+    * `:commits` - list of commit refs to compare (two or more)
+    * `:is_ancestor` - check if first is ancestor of second (`--is-ancestor`)
+    * `:fork_point` - find fork point (`--fork-point`)
+    * `:octopus` - find octopus merge base (`--octopus`)
+    * `:all` - output all merge bases (`--all`)
+    * `:independent` - list independent commits (`--independent`)
+
+  ## Examples
+
+      Git.merge_base(commits: ["main", "feature"])
+      Git.merge_base(commits: ["main", "feature"], is_ancestor: true)
+      Git.merge_base(commits: ["main", "feature"], all: true)
+
+  """
+  @spec merge_base(keyword()) ::
+          {:ok, String.t() | boolean() | [String.t()]} | {:error, term()}
+  def merge_base(opts \\ []) do
+    {config, rest} = Keyword.pop(opts, :config, Config.new())
+    command = struct!(Git.Commands.MergeBase, rest)
+    Git.Command.run(Git.Commands.MergeBase, command, config)
+  end
+
+  @doc """
+  Runs `git cherry` to find commits not yet applied upstream.
+
+  Returns a list of `Git.CherryEntry` structs. Each entry indicates
+  whether a commit has already been applied upstream and includes the
+  SHA (and subject when `verbose: true`).
+
+  ## Options
+
+    * `:config` - a `Git.Config` struct (default: `Git.Config.new()`)
+    * `:upstream` - upstream branch (required)
+    * `:head` - head branch (default: HEAD)
+    * `:limit` - limit ref
+    * `:verbose` - include commit subject (`-v`)
+
+  ## Examples
+
+      Git.cherry(upstream: "main")
+      Git.cherry(upstream: "main", head: "feature", verbose: true)
+
+  """
+  @spec cherry(keyword()) :: {:ok, [Git.CherryEntry.t()]} | {:error, term()}
+  def cherry(opts \\ []) do
+    {config, rest} = Keyword.pop(opts, :config, Config.new())
+    command = struct!(Git.Commands.Cherry, rest)
+    Git.Command.run(Git.Commands.Cherry, command, config)
+  end
+
+  @doc """
+  Runs `git range-diff` to compare two sequences of commits.
+
+  Supports both the two-range form (using `range1` and `range2`) and the
+  three-argument form (using `rev1`, `rev2`, and `rev3`).
+
+  ## Options
+
+    * `:config` - a `Git.Config` struct (default: `Git.Config.new()`)
+    * `:range1` - first revision range (e.g. `"main..topic-v1"`)
+    * `:range2` - second revision range (e.g. `"main..topic-v2"`)
+    * `:rev1` - base revision (three-arg form)
+    * `:rev2` - first revision (three-arg form)
+    * `:rev3` - second revision (three-arg form)
+    * `:stat` - show diffstat (`--stat`)
+    * `:no_patch` - suppress diff output (`--no-patch`)
+    * `:creation_factor` - percentage for matching commits (`--creation-factor=N`)
+    * `:no_dual_color` - disable dual-color mode (`--no-dual-color`)
+    * `:left_only` - show only left-side commits (`--left-only`)
+    * `:right_only` - show only right-side commits (`--right-only`)
+    * `:no_notes` - do not show notes (`--no-notes`)
+
+  ## Examples
+
+      Git.range_diff(range1: "main..topic-v1", range2: "main..topic-v2")
+      Git.range_diff(rev1: "main", rev2: "topic-v1", rev3: "topic-v2")
+      Git.range_diff(range1: "main..v1", range2: "main..v2", stat: true)
+
+  """
+  @spec range_diff(keyword()) :: {:ok, String.t()} | {:error, term()}
+  def range_diff(opts \\ []) do
+    {config, rest} = Keyword.pop(opts, :config, Config.new())
+    command = struct!(Git.Commands.RangeDiff, rest)
+    Git.Command.run(Git.Commands.RangeDiff, command, config)
+  end
+
+  @doc """
+  Runs `git sparse-checkout` to manage sparse-checkout patterns.
+
+  ## Options
+
+    * `:config` - a `Git.Config` struct (default: `Git.Config.new()`)
+    * `:init` - initialize sparse-checkout
+    * `:set` - list of patterns to set
+    * `:add` - list of patterns to add
+    * `:list` - list current patterns (default `true`)
+    * `:disable` - disable sparse-checkout
+    * `:reapply` - reapply current sparse-checkout rules
+    * `:check_rules` - check sparse-checkout rules
+    * `:cone` - use cone mode (`--cone`)
+    * `:no_cone` - use non-cone mode (`--no-cone`)
+    * `:sparse_index` - use sparse index (`--sparse-index`)
+    * `:no_sparse_index` - do not use sparse index (`--no-sparse-index`)
+
+  ## Examples
+
+      Git.sparse_checkout()
+      Git.sparse_checkout(init: true, cone: true)
+      Git.sparse_checkout(set: ["src/", "docs/"])
+      Git.sparse_checkout(disable: true)
+
+  """
+  @spec sparse_checkout(keyword()) ::
+          {:ok, [String.t()]} | {:ok, :done} | {:error, term()}
+  def sparse_checkout(opts \\ []) do
+    {config, rest} = Keyword.pop(opts, :config, Config.new())
+    command = struct!(Git.Commands.SparseCheckout, rest)
+    Git.Command.run(Git.Commands.SparseCheckout, command, config)
+  end
+
+  @doc """
+  Runs `git cat-file` to provide content or type/size info for repository objects.
+
+  The object (SHA or ref) is required as the first argument.
+
+  ## Options
+
+    * `:config` - a `Git.Config` struct (default: `Git.Config.new()`)
+    * `:type` - show object type (`-t`)
+    * `:size` - show object size (`-s`)
+    * `:print` - pretty-print object content (`-p`)
+    * `:exists` - check if object exists (`-e`); returns `{:ok, true}` or `{:ok, false}`
+    * `:textconv` - show content with textconv filter (`--textconv`)
+    * `:filters` - show content with filters applied (`--filters`)
+
+  ## Examples
+
+      Git.cat_file("HEAD", type: true)
+      Git.cat_file("abc1234", size: true)
+      Git.cat_file("HEAD", print: true)
+      Git.cat_file("deadbeef", exists: true)
+
+  """
+  @spec cat_file(String.t(), keyword()) ::
+          {:ok, atom()}
+          | {:ok, integer()}
+          | {:ok, String.t()}
+          | {:ok, boolean()}
+          | {:error, term()}
+  def cat_file(object, opts \\ []) when is_binary(object) do
+    {config, rest} = Keyword.pop(opts, :config, Config.new())
+    command = struct!(Git.Commands.CatFile, [{:object, object} | rest])
+    Git.Command.run(Git.Commands.CatFile, command, config)
+  end
+
+  @doc """
+  Runs `git check-ignore` to test whether paths are ignored by `.gitignore`.
+
+  ## Options
+
+    * `:config` - a `Git.Config` struct (default: `Git.Config.new()`)
+    * `:paths` - list of paths to check (required)
+    * `:verbose` - show matching pattern info (`-v`)
+    * `:non_matching` - also show non-matching paths (`-n`, requires `-v`)
+    * `:no_index` - do not look at the index (`--no-index`)
+    * `:quiet` - suppress output, use exit status only (`-q`)
+
+  ## Examples
+
+      Git.check_ignore(paths: ["build/", "tmp.log"])
+      Git.check_ignore(paths: ["src/main.ex"], verbose: true)
+
+  """
+  @spec check_ignore(keyword()) :: {:ok, [String.t()] | [map()]} | {:error, term()}
+  def check_ignore(opts \\ []) do
+    {config, rest} = Keyword.pop(opts, :config, Config.new())
+    command = struct!(Git.Commands.CheckIgnore, rest)
+    Git.Command.run(Git.Commands.CheckIgnore, command, config)
+  end
+
+  @doc """
+  Runs `git notes` to manage notes attached to objects.
+
+  ## Options
+
+    * `:config` - a `Git.Config` struct (default: `Git.Config.new()`)
+    * `:list` - list notes (default `true`)
+    * `:show` - show note for a ref (string)
+    * `:add` - add a note (boolean)
+    * `:append` - append to an existing note (boolean)
+    * `:message` - note message (`-m`, for add/append)
+    * `:ref` - commit ref for add/append/show
+    * `:force` - overwrite existing note (`-f`)
+    * `:remove` - remove note from ref (string)
+    * `:prune` - prune notes for unreachable objects (boolean)
+    * `:notes_ref` - use alternate notes ref (`--ref=`)
+
+  Note: `notes edit` is not supported because it launches an interactive editor.
+
+  ## Examples
+
+      Git.notes()
+      Git.notes(show: "HEAD")
+      Git.notes(add: true, message: "review passed", ref: "HEAD")
+      Git.notes(remove: "HEAD")
+
+  """
+  @spec notes(keyword()) ::
+          {:ok, [map()]} | {:ok, String.t()} | {:ok, :done} | {:error, term()}
+  def notes(opts \\ []) do
+    {config, rest} = Keyword.pop(opts, :config, Config.new())
+    command = struct!(Git.Commands.Notes, rest)
+    Git.Command.run(Git.Commands.Notes, command, config)
+  end
 end

--- a/lib/git/cherry_entry.ex
+++ b/lib/git/cherry_entry.ex
@@ -1,0 +1,72 @@
+defmodule Git.CherryEntry do
+  @moduledoc """
+  Parsed representation of a `git cherry` output line.
+
+  Each entry indicates whether a commit has been applied upstream
+  (cherry-picked) and includes the commit SHA and optionally the
+  subject line when verbose mode is used.
+  """
+
+  @type t :: %__MODULE__{
+          applied: boolean(),
+          sha: String.t(),
+          subject: String.t() | nil
+        }
+
+  defstruct applied: false,
+            sha: "",
+            subject: nil
+
+  @doc """
+  Parses the output of `git cherry` into a list of `Git.CherryEntry` structs.
+
+  Each line starts with `+` (not applied upstream) or `-` (already applied),
+  followed by a SHA. With `-v`, a subject line follows the SHA.
+
+  ## Examples
+
+      iex> Git.CherryEntry.parse("+ abc1234\\n- def5678\\n")
+      [
+        %Git.CherryEntry{applied: false, sha: "abc1234", subject: nil},
+        %Git.CherryEntry{applied: true, sha: "def5678", subject: nil}
+      ]
+
+      iex> Git.CherryEntry.parse("+ abc1234 add feature\\n- def5678 fix bug\\n")
+      [
+        %Git.CherryEntry{applied: false, sha: "abc1234", subject: "add feature"},
+        %Git.CherryEntry{applied: true, sha: "def5678", subject: "fix bug"}
+      ]
+
+      iex> Git.CherryEntry.parse("")
+      []
+
+  """
+  @spec parse(String.t()) :: [t()]
+  def parse(output) do
+    output
+    |> String.split("\n", trim: true)
+    |> Enum.map(&parse_line/1)
+  end
+
+  @spec parse_line(String.t()) :: t()
+  defp parse_line(line) do
+    case Regex.run(~r/^([+-])\s+(\S+)(?:\s+(.+))?$/, String.trim(line)) do
+      [_, sign, sha, subject] ->
+        %__MODULE__{
+          applied: sign == "-",
+          sha: sha,
+          subject: subject
+        }
+
+      [_, sign, sha] ->
+        %__MODULE__{
+          applied: sign == "-",
+          sha: sha,
+          subject: nil
+        }
+
+      _ ->
+        %__MODULE__{sha: String.trim(line)}
+    end
+  end
+end

--- a/lib/git/commands/cat_file.ex
+++ b/lib/git/commands/cat_file.ex
@@ -1,0 +1,144 @@
+defmodule Git.Commands.CatFile do
+  @moduledoc """
+  Implements the `Git.Command` behaviour for `git cat-file`.
+
+  Provides content or type/size information for repository objects.
+  Supports pretty-printing object contents, querying object type or size,
+  and checking whether an object exists.
+
+  Interactive and batch modes are intentionally not supported because they
+  require stdin interaction which cannot be driven programmatically.
+  """
+
+  @behaviour Git.Command
+
+  @type t :: %__MODULE__{
+          object: String.t() | nil,
+          type: boolean(),
+          size: boolean(),
+          print: boolean(),
+          exists: boolean(),
+          textconv: boolean(),
+          filters: boolean()
+        }
+
+  defstruct object: nil,
+            type: false,
+            size: false,
+            print: false,
+            exists: false,
+            textconv: false,
+            filters: false
+
+  # Process dictionary key used to communicate the output mode from args/1
+  # to parse_output/2. Both are called from the same process inside
+  # Git.Command.run/3, so this is safe even with async tests.
+  @mode_key :__git_cat_file_mode__
+
+  @doc """
+  Returns the argument list for `git cat-file`.
+
+  Builds the argument list from the struct fields. Exactly one of the mode
+  flags (`:type`, `:size`, `:print`, `:exists`) should be set, or none for
+  the default pretty-print behaviour.
+
+  ## Examples
+
+      iex> Git.Commands.CatFile.args(%Git.Commands.CatFile{object: "HEAD", type: true})
+      ["cat-file", "-t", "HEAD"]
+
+      iex> Git.Commands.CatFile.args(%Git.Commands.CatFile{object: "HEAD", size: true})
+      ["cat-file", "-s", "HEAD"]
+
+      iex> Git.Commands.CatFile.args(%Git.Commands.CatFile{object: "HEAD", print: true})
+      ["cat-file", "-p", "HEAD"]
+
+      iex> Git.Commands.CatFile.args(%Git.Commands.CatFile{object: "HEAD", exists: true})
+      ["cat-file", "-e", "HEAD"]
+
+      iex> Git.Commands.CatFile.args(%Git.Commands.CatFile{object: "HEAD", textconv: true})
+      ["cat-file", "--textconv", "HEAD"]
+
+      iex> Git.Commands.CatFile.args(%Git.Commands.CatFile{object: "HEAD", filters: true})
+      ["cat-file", "--filters", "HEAD"]
+
+  """
+  @spec args(t()) :: [String.t()]
+  @impl true
+  def args(%__MODULE__{type: true} = command) do
+    Process.put(@mode_key, :type)
+    ["cat-file", "-t", command.object]
+  end
+
+  def args(%__MODULE__{size: true} = command) do
+    Process.put(@mode_key, :size)
+    ["cat-file", "-s", command.object]
+  end
+
+  def args(%__MODULE__{print: true} = command) do
+    Process.put(@mode_key, :print)
+    ["cat-file", "-p", command.object]
+  end
+
+  def args(%__MODULE__{exists: true} = command) do
+    Process.put(@mode_key, :exists)
+    ["cat-file", "-e", command.object]
+  end
+
+  def args(%__MODULE__{textconv: true} = command) do
+    Process.put(@mode_key, :print)
+    ["cat-file", "--textconv", command.object]
+  end
+
+  def args(%__MODULE__{filters: true} = command) do
+    Process.put(@mode_key, :print)
+    ["cat-file", "--filters", command.object]
+  end
+
+  def args(%__MODULE__{} = command) do
+    Process.put(@mode_key, :print)
+    ["cat-file", "-p", command.object]
+  end
+
+  @doc """
+  Parses the output of `git cat-file`.
+
+  - For `:type` mode, returns `{:ok, atom}` where atom is one of
+    `:blob`, `:tree`, `:commit`, or `:tag`.
+  - For `:size` mode, returns `{:ok, integer}`.
+  - For `:print` mode (including textconv and filters), returns
+    `{:ok, String.t()}`.
+  - For `:exists` mode, exit code 0 returns `{:ok, true}` and exit
+    code 1 returns `{:ok, false}` (not an error).
+  """
+  @spec parse_output(String.t(), non_neg_integer()) ::
+          {:ok, atom()}
+          | {:ok, integer()}
+          | {:ok, String.t()}
+          | {:ok, boolean()}
+          | {:error, {String.t(), non_neg_integer()}}
+  @impl true
+  def parse_output(stdout, exit_code) do
+    mode = Process.get(@mode_key, :print)
+
+    case {mode, exit_code} do
+      {:exists, 0} ->
+        {:ok, true}
+
+      {:exists, 1} ->
+        {:ok, false}
+
+      {:type, 0} ->
+        {:ok, stdout |> String.trim() |> String.to_atom()}
+
+      {:size, 0} ->
+        {:ok, stdout |> String.trim() |> String.to_integer()}
+
+      {:print, 0} ->
+        {:ok, String.trim(stdout)}
+
+      {_, exit_code} when exit_code != 0 ->
+        {:error, {stdout, exit_code}}
+    end
+  end
+end

--- a/lib/git/commands/check_ignore.ex
+++ b/lib/git/commands/check_ignore.ex
@@ -1,0 +1,136 @@
+defmodule Git.Commands.CheckIgnore do
+  @moduledoc """
+  Implements the `Git.Command` behaviour for `git check-ignore`.
+
+  Checks whether given paths are ignored by `.gitignore` rules. Supports
+  verbose output showing which pattern matched and non-matching mode.
+
+  Stdin mode (`--stdin`) is intentionally not supported because it requires
+  stdin piping which cannot be driven programmatically via `System.cmd/3`.
+  """
+
+  @behaviour Git.Command
+
+  @type t :: %__MODULE__{
+          paths: [String.t()],
+          verbose: boolean(),
+          non_matching: boolean(),
+          no_index: boolean(),
+          quiet: boolean()
+        }
+
+  defstruct paths: [],
+            verbose: false,
+            non_matching: false,
+            no_index: false,
+            quiet: false
+
+  # Process dictionary key used to communicate the output mode from args/1
+  # to parse_output/2.
+  @mode_key :__git_check_ignore_mode__
+
+  @doc """
+  Returns the argument list for `git check-ignore`.
+
+  ## Examples
+
+      iex> Git.Commands.CheckIgnore.args(%Git.Commands.CheckIgnore{paths: ["build/", "tmp.log"]})
+      ["check-ignore", "build/", "tmp.log"]
+
+      iex> Git.Commands.CheckIgnore.args(%Git.Commands.CheckIgnore{paths: ["foo"], verbose: true})
+      ["check-ignore", "-v", "foo"]
+
+      iex> Git.Commands.CheckIgnore.args(%Git.Commands.CheckIgnore{paths: ["foo"], verbose: true, non_matching: true})
+      ["check-ignore", "-v", "-n", "foo"]
+
+      iex> Git.Commands.CheckIgnore.args(%Git.Commands.CheckIgnore{paths: ["foo"], no_index: true})
+      ["check-ignore", "--no-index", "foo"]
+
+      iex> Git.Commands.CheckIgnore.args(%Git.Commands.CheckIgnore{paths: ["foo"], quiet: true})
+      ["check-ignore", "-q", "foo"]
+
+  """
+  @spec args(t()) :: [String.t()]
+  @impl true
+  def args(%__MODULE__{} = command) do
+    mode = if command.verbose, do: :verbose, else: :default
+    Process.put(@mode_key, mode)
+
+    base = ["check-ignore"]
+
+    base
+    |> maybe_add_flag(command.verbose, "-v")
+    |> maybe_add_flag(command.non_matching, "-n")
+    |> maybe_add_flag(command.no_index, "--no-index")
+    |> maybe_add_flag(command.quiet, "-q")
+    |> append_paths(command.paths)
+  end
+
+  @doc """
+  Parses the output of `git check-ignore`.
+
+  - Default mode: returns `{:ok, [String.t()]}` with the list of ignored paths.
+  - Verbose mode: returns `{:ok, [map]}` where each map has `:source`,
+    `:line_number`, `:pattern`, and `:path` keys.
+  - Exit code 1 means no paths matched, which returns `{:ok, []}` (not an error).
+  """
+  @spec parse_output(String.t(), non_neg_integer()) ::
+          {:ok, [String.t()] | [map()]} | {:error, {String.t(), non_neg_integer()}}
+  @impl true
+  def parse_output(stdout, exit_code) when exit_code in [0, 1] do
+    mode = Process.get(@mode_key, :default)
+
+    if exit_code == 1 or String.trim(stdout) == "" do
+      {:ok, []}
+    else
+      case mode do
+        :default ->
+          paths =
+            stdout
+            |> String.split("\n", trim: true)
+            |> Enum.map(&String.trim/1)
+
+          {:ok, paths}
+
+        :verbose ->
+          entries =
+            stdout
+            |> String.split("\n", trim: true)
+            |> Enum.map(&parse_verbose_line/1)
+            |> Enum.reject(&is_nil/1)
+
+          {:ok, entries}
+      end
+    end
+  end
+
+  def parse_output(stdout, exit_code), do: {:error, {stdout, exit_code}}
+
+  defp parse_verbose_line(line) do
+    # Verbose format: "source:line_number:pattern\tpath"
+    # Non-matching (with -n): "::\tpath"
+    with [info, path] <- String.split(line, "\t", parts: 2),
+         [source, line_num, pattern] <- String.split(info, ":", parts: 3) do
+      %{
+        source: source,
+        line_number: parse_line_number(line_num),
+        pattern: pattern,
+        path: String.trim(path)
+      }
+    else
+      _ -> nil
+    end
+  end
+
+  defp parse_line_number(str) do
+    case Integer.parse(str) do
+      {n, _} -> n
+      :error -> 0
+    end
+  end
+
+  defp maybe_add_flag(args, true, flag), do: args ++ [flag]
+  defp maybe_add_flag(args, false, _flag), do: args
+
+  defp append_paths(args, paths), do: args ++ paths
+end

--- a/lib/git/commands/cherry.ex
+++ b/lib/git/commands/cherry.ex
@@ -1,0 +1,76 @@
+defmodule Git.Commands.Cherry do
+  @moduledoc """
+  Implements the `Git.Command` behaviour for `git cherry`.
+
+  Finds commits in the current branch (or `head`) that have not yet been
+  applied to `upstream`. Each commit is marked with `+` (not applied) or
+  `-` (already applied upstream, i.e. an equivalent patch exists).
+  """
+
+  @behaviour Git.Command
+
+  alias Git.CherryEntry
+
+  @type t :: %__MODULE__{
+          upstream: String.t() | nil,
+          head: String.t() | nil,
+          limit: String.t() | nil,
+          verbose: boolean()
+        }
+
+  defstruct upstream: nil,
+            head: nil,
+            limit: nil,
+            verbose: false
+
+  @doc """
+  Builds the argument list for `git cherry`.
+
+  ## Examples
+
+      iex> Git.Commands.Cherry.args(%Git.Commands.Cherry{upstream: "main"})
+      ["cherry", "main"]
+
+      iex> Git.Commands.Cherry.args(%Git.Commands.Cherry{upstream: "main", verbose: true})
+      ["cherry", "-v", "main"]
+
+      iex> Git.Commands.Cherry.args(%Git.Commands.Cherry{upstream: "main", head: "feature"})
+      ["cherry", "main", "feature"]
+
+      iex> Git.Commands.Cherry.args(%Git.Commands.Cherry{upstream: "main", head: "feature", limit: "v1.0"})
+      ["cherry", "main", "feature", "v1.0"]
+
+  """
+  @spec args(t()) :: [String.t()]
+  @impl true
+  def args(%__MODULE__{} = command) do
+    base = ["cherry"]
+
+    base
+    |> maybe_add_flag(command.verbose, "-v")
+    |> maybe_add_positional(command.upstream)
+    |> maybe_add_positional(command.head)
+    |> maybe_add_positional(command.limit)
+  end
+
+  @doc """
+  Parses the output of `git cherry`.
+
+  Returns `{:ok, [%Git.CherryEntry{}]}` on success (exit code 0).
+  An empty output produces an empty list.
+  """
+  @spec parse_output(String.t(), non_neg_integer()) ::
+          {:ok, [CherryEntry.t()]} | {:error, {String.t(), non_neg_integer()}}
+  @impl true
+  def parse_output(stdout, 0) do
+    {:ok, CherryEntry.parse(stdout)}
+  end
+
+  def parse_output(stdout, exit_code), do: {:error, {stdout, exit_code}}
+
+  defp maybe_add_flag(args, true, flag), do: args ++ [flag]
+  defp maybe_add_flag(args, false, _flag), do: args
+
+  defp maybe_add_positional(args, nil), do: args
+  defp maybe_add_positional(args, value), do: args ++ [value]
+end

--- a/lib/git/commands/merge_base.ex
+++ b/lib/git/commands/merge_base.ex
@@ -1,0 +1,124 @@
+defmodule Git.Commands.MergeBase do
+  @moduledoc """
+  Implements the `Git.Command` behaviour for `git merge-base`.
+
+  Finds the best common ancestor(s) between two or more commits for use
+  in a three-way merge. Also supports checking ancestor relationships
+  and finding fork points.
+  """
+
+  @behaviour Git.Command
+
+  @mode_key :__merge_base_output_mode
+
+  @type t :: %__MODULE__{
+          commits: [String.t()],
+          is_ancestor: boolean(),
+          fork_point: boolean(),
+          octopus: boolean(),
+          all: boolean(),
+          independent: boolean()
+        }
+
+  defstruct commits: [],
+            is_ancestor: false,
+            fork_point: false,
+            octopus: false,
+            all: false,
+            independent: false
+
+  @doc """
+  Builds the argument list for `git merge-base`.
+
+  ## Examples
+
+      iex> Git.Commands.MergeBase.args(%Git.Commands.MergeBase{commits: ["main", "feature"]})
+      ["merge-base", "main", "feature"]
+
+      iex> Git.Commands.MergeBase.args(%Git.Commands.MergeBase{commits: ["main", "feature"], is_ancestor: true})
+      ["merge-base", "--is-ancestor", "main", "feature"]
+
+      iex> Git.Commands.MergeBase.args(%Git.Commands.MergeBase{commits: ["main", "feature"], all: true})
+      ["merge-base", "--all", "main", "feature"]
+
+      iex> Git.Commands.MergeBase.args(%Git.Commands.MergeBase{commits: ["a", "b", "c"], octopus: true})
+      ["merge-base", "--octopus", "a", "b", "c"]
+
+      iex> Git.Commands.MergeBase.args(%Git.Commands.MergeBase{commits: ["a", "b", "c"], independent: true})
+      ["merge-base", "--independent", "a", "b", "c"]
+
+      iex> Git.Commands.MergeBase.args(%Git.Commands.MergeBase{commits: ["main", "feature"], fork_point: true})
+      ["merge-base", "--fork-point", "main", "feature"]
+
+  """
+  @spec args(t()) :: [String.t()]
+  @impl true
+  def args(%__MODULE__{} = command) do
+    set_output_mode(command)
+    base = ["merge-base"]
+
+    base
+    |> maybe_add_flag(command.is_ancestor, "--is-ancestor")
+    |> maybe_add_flag(command.fork_point, "--fork-point")
+    |> maybe_add_flag(command.octopus, "--octopus")
+    |> maybe_add_flag(command.all, "--all")
+    |> maybe_add_flag(command.independent, "--independent")
+    |> Kernel.++(command.commits)
+  end
+
+  @doc """
+  Parses the output of `git merge-base`.
+
+  The output mode depends on the flags used:
+
+    * Default: returns `{:ok, String.t()}` with the ancestor SHA
+    * With `is_ancestor: true`: exit 0 = `{:ok, true}`, exit 1 = `{:ok, false}`
+    * With `all: true` or `independent: true`: returns `{:ok, [String.t()]}`
+  """
+  @spec parse_output(String.t(), non_neg_integer()) ::
+          {:ok, String.t() | boolean() | [String.t()]}
+          | {:error, {String.t(), non_neg_integer()}}
+  @impl true
+  def parse_output(stdout, exit_code) do
+    parse_by_mode(stdout, exit_code, output_mode())
+  end
+
+  defp output_mode do
+    Process.get(@mode_key, :single)
+  end
+
+  @doc false
+  def set_output_mode(%__MODULE__{} = command) do
+    mode =
+      cond do
+        command.is_ancestor -> :is_ancestor
+        command.all -> :multi
+        command.independent -> :multi
+        true -> :single
+      end
+
+    Process.put(@mode_key, mode)
+    command
+  end
+
+  defp parse_by_mode(_stdout, 0, :is_ancestor), do: {:ok, true}
+  defp parse_by_mode(_stdout, 1, :is_ancestor), do: {:ok, false}
+
+  defp parse_by_mode(stdout, 0, :multi) do
+    shas =
+      stdout
+      |> String.split("\n", trim: true)
+      |> Enum.map(&String.trim/1)
+
+    {:ok, shas}
+  end
+
+  defp parse_by_mode(stdout, 0, :single) do
+    {:ok, String.trim(stdout)}
+  end
+
+  defp parse_by_mode(stdout, exit_code, _mode), do: {:error, {stdout, exit_code}}
+
+  defp maybe_add_flag(args, true, flag), do: args ++ [flag]
+  defp maybe_add_flag(args, false, _flag), do: args
+end

--- a/lib/git/commands/notes.ex
+++ b/lib/git/commands/notes.ex
@@ -1,0 +1,192 @@
+defmodule Git.Commands.Notes do
+  @moduledoc """
+  Implements the `Git.Command` behaviour for `git notes`.
+
+  Supports listing notes, showing a note for a specific ref, adding notes,
+  appending to existing notes, removing notes, and pruning notes for
+  unreachable objects.
+
+  Edit mode (`git notes edit`) is intentionally not supported because it
+  launches an interactive editor which cannot be driven programmatically.
+  """
+
+  @behaviour Git.Command
+
+  @type t :: %__MODULE__{
+          list: boolean(),
+          show: String.t() | nil,
+          add: boolean(),
+          append: boolean(),
+          message: String.t() | nil,
+          ref: String.t() | nil,
+          force: boolean(),
+          remove: String.t() | nil,
+          prune: boolean(),
+          notes_ref: String.t() | nil
+        }
+
+  defstruct list: true,
+            show: nil,
+            add: false,
+            append: false,
+            message: nil,
+            ref: nil,
+            force: false,
+            remove: nil,
+            prune: false,
+            notes_ref: nil
+
+  # Process dictionary key used to communicate the operation mode from args/1
+  # to parse_output/2. Both are called from the same process inside
+  # Git.Command.run/3, so this is safe even with async tests.
+  @mode_key :__git_notes_mode__
+
+  @doc """
+  Returns the argument list for `git notes`.
+
+  ## Examples
+
+      iex> Git.Commands.Notes.args(%Git.Commands.Notes{})
+      ["notes", "list"]
+
+      iex> Git.Commands.Notes.args(%Git.Commands.Notes{show: "HEAD"})
+      ["notes", "show", "HEAD"]
+
+      iex> Git.Commands.Notes.args(%Git.Commands.Notes{add: true, message: "my note", ref: "HEAD"})
+      ["notes", "add", "-m", "my note", "HEAD"]
+
+      iex> Git.Commands.Notes.args(%Git.Commands.Notes{add: true, message: "note", ref: "HEAD", force: true})
+      ["notes", "add", "-f", "-m", "note", "HEAD"]
+
+      iex> Git.Commands.Notes.args(%Git.Commands.Notes{append: true, message: "more", ref: "HEAD"})
+      ["notes", "append", "-m", "more", "HEAD"]
+
+      iex> Git.Commands.Notes.args(%Git.Commands.Notes{remove: "HEAD"})
+      ["notes", "remove", "HEAD"]
+
+      iex> Git.Commands.Notes.args(%Git.Commands.Notes{prune: true})
+      ["notes", "prune"]
+
+      iex> Git.Commands.Notes.args(%Git.Commands.Notes{notes_ref: "custom"})
+      ["notes", "--ref=custom", "list"]
+
+  """
+  @spec args(t()) :: [String.t()]
+  @impl true
+  def args(%__MODULE__{add: true} = command) do
+    Process.put(@mode_key, :mutation)
+
+    base = ["notes"]
+    base = maybe_add_notes_ref(base, command.notes_ref)
+
+    (base ++ ["add"])
+    |> maybe_add_flag(command.force, "-f")
+    |> maybe_add_message(command.message)
+    |> maybe_add_ref(command.ref)
+  end
+
+  def args(%__MODULE__{append: true} = command) do
+    Process.put(@mode_key, :mutation)
+
+    base = ["notes"]
+    base = maybe_add_notes_ref(base, command.notes_ref)
+
+    (base ++ ["append"])
+    |> maybe_add_message(command.message)
+    |> maybe_add_ref(command.ref)
+  end
+
+  def args(%__MODULE__{remove: ref} = command) when is_binary(ref) do
+    Process.put(@mode_key, :mutation)
+
+    base = ["notes"]
+    base = maybe_add_notes_ref(base, command.notes_ref)
+    base ++ ["remove", ref]
+  end
+
+  def args(%__MODULE__{prune: true} = command) do
+    Process.put(@mode_key, :mutation)
+
+    base = ["notes"]
+    base = maybe_add_notes_ref(base, command.notes_ref)
+    base ++ ["prune"]
+  end
+
+  def args(%__MODULE__{show: ref} = command) when is_binary(ref) do
+    Process.put(@mode_key, :show)
+
+    base = ["notes"]
+    base = maybe_add_notes_ref(base, command.notes_ref)
+    base ++ ["show", ref]
+  end
+
+  def args(%__MODULE__{} = command) do
+    Process.put(@mode_key, :list)
+
+    base = ["notes"]
+    base = maybe_add_notes_ref(base, command.notes_ref)
+    base ++ ["list"]
+  end
+
+  @doc """
+  Parses the output of `git notes`.
+
+  - For `:list` mode, parses lines of "note_sha commit_sha" into a list of maps.
+  - For `:show` mode, returns the note content as a string.
+  - For mutation modes (add, append, remove, prune), returns `{:ok, :done}`.
+  """
+  @spec parse_output(String.t(), non_neg_integer()) ::
+          {:ok, [map()]}
+          | {:ok, String.t()}
+          | {:ok, :done}
+          | {:error, {String.t(), non_neg_integer()}}
+  @impl true
+  def parse_output(stdout, 0) do
+    mode = Process.get(@mode_key, :list)
+
+    case mode do
+      :mutation ->
+        {:ok, :done}
+
+      :show ->
+        {:ok, String.trim(stdout)}
+
+      :list ->
+        if String.trim(stdout) == "" do
+          {:ok, []}
+        else
+          entries =
+            stdout
+            |> String.split("\n", trim: true)
+            |> Enum.map(&parse_list_line/1)
+            |> Enum.reject(&is_nil/1)
+
+          {:ok, entries}
+        end
+    end
+  end
+
+  def parse_output(stdout, exit_code), do: {:error, {stdout, exit_code}}
+
+  defp parse_list_line(line) do
+    case String.split(String.trim(line), ~r/\s+/, parts: 2) do
+      [note_sha, commit_sha] ->
+        %{note_sha: note_sha, commit_sha: commit_sha}
+
+      _ ->
+        nil
+    end
+  end
+
+  defp maybe_add_flag(args, true, flag), do: args ++ [flag]
+  defp maybe_add_flag(args, false, _flag), do: args
+
+  defp maybe_add_message(args, nil), do: args
+  defp maybe_add_message(args, message) when is_binary(message), do: args ++ ["-m", message]
+
+  defp maybe_add_ref(args, nil), do: args
+  defp maybe_add_ref(args, ref) when is_binary(ref), do: args ++ [ref]
+
+  defp maybe_add_notes_ref(args, nil), do: args
+  defp maybe_add_notes_ref(args, ref) when is_binary(ref), do: args ++ ["--ref=#{ref}"]
+end

--- a/lib/git/commands/range_diff.ex
+++ b/lib/git/commands/range_diff.ex
@@ -1,0 +1,113 @@
+defmodule Git.Commands.RangeDiff do
+  @moduledoc """
+  Implements the `Git.Command` behaviour for `git range-diff`.
+
+  Compares two sequences of commits (revision ranges). Supports both
+  the two-range form (`range1 range2`) and the three-argument form
+  (`rev1 rev2 rev3`).
+  """
+
+  @behaviour Git.Command
+
+  @type t :: %__MODULE__{
+          range1: String.t() | nil,
+          range2: String.t() | nil,
+          rev1: String.t() | nil,
+          rev2: String.t() | nil,
+          rev3: String.t() | nil,
+          stat: boolean(),
+          no_patch: boolean(),
+          creation_factor: non_neg_integer() | nil,
+          no_dual_color: boolean(),
+          left_only: boolean(),
+          right_only: boolean(),
+          no_notes: boolean()
+        }
+
+  defstruct range1: nil,
+            range2: nil,
+            rev1: nil,
+            rev2: nil,
+            rev3: nil,
+            stat: false,
+            no_patch: false,
+            creation_factor: nil,
+            no_dual_color: false,
+            left_only: false,
+            right_only: false,
+            no_notes: false
+
+  @doc """
+  Returns the argument list for `git range-diff`.
+
+  Builds `git range-diff [flags] range1 range2` when `range1` and `range2`
+  are set, or `git range-diff [flags] rev1 rev2 rev3` when the three-argument
+  form is used.
+
+  ## Examples
+
+      iex> Git.Commands.RangeDiff.args(%Git.Commands.RangeDiff{range1: "main..topic-v1", range2: "main..topic-v2"})
+      ["range-diff", "main..topic-v1", "main..topic-v2"]
+
+      iex> Git.Commands.RangeDiff.args(%Git.Commands.RangeDiff{rev1: "main", rev2: "topic-v1", rev3: "topic-v2"})
+      ["range-diff", "main", "topic-v1", "topic-v2"]
+
+      iex> Git.Commands.RangeDiff.args(%Git.Commands.RangeDiff{range1: "main..v1", range2: "main..v2", stat: true})
+      ["range-diff", "--stat", "main..v1", "main..v2"]
+
+      iex> Git.Commands.RangeDiff.args(%Git.Commands.RangeDiff{range1: "a..b", range2: "a..c", creation_factor: 50})
+      ["range-diff", "--creation-factor=50", "a..b", "a..c"]
+
+  """
+  @spec args(t()) :: [String.t()]
+  @impl true
+  def args(%__MODULE__{} = command) do
+    base = ["range-diff"]
+
+    flags =
+      base
+      |> maybe_add_flag(command.stat, "--stat")
+      |> maybe_add_flag(command.no_patch, "--no-patch")
+      |> maybe_add_creation_factor(command.creation_factor)
+      |> maybe_add_flag(command.no_dual_color, "--no-dual-color")
+      |> maybe_add_flag(command.left_only, "--left-only")
+      |> maybe_add_flag(command.right_only, "--right-only")
+      |> maybe_add_flag(command.no_notes, "--no-notes")
+
+    flags ++ positional_args(command)
+  end
+
+  @doc """
+  Parses the output of `git range-diff`.
+
+  On success (exit code 0), returns `{:ok, raw_output}` as a string.
+  Range-diff output contains color codes and varying formats, so returning
+  the raw string is the practical choice.
+  On failure, returns `{:error, {stdout, exit_code}}`.
+  """
+  @spec parse_output(String.t(), non_neg_integer()) ::
+          {:ok, String.t()} | {:error, {String.t(), non_neg_integer()}}
+  @impl true
+  def parse_output(stdout, 0), do: {:ok, stdout}
+  def parse_output(stdout, exit_code), do: {:error, {stdout, exit_code}}
+
+  defp positional_args(%__MODULE__{range1: r1, range2: r2})
+       when is_binary(r1) and is_binary(r2) do
+    [r1, r2]
+  end
+
+  defp positional_args(%__MODULE__{rev1: r1, rev2: r2, rev3: r3})
+       when is_binary(r1) and is_binary(r2) and is_binary(r3) do
+    [r1, r2, r3]
+  end
+
+  defp positional_args(_), do: []
+
+  defp maybe_add_flag(args, false, _flag), do: args
+  defp maybe_add_flag(args, true, flag), do: args ++ [flag]
+
+  defp maybe_add_creation_factor(args, nil), do: args
+
+  defp maybe_add_creation_factor(args, n) when is_integer(n),
+    do: args ++ ["--creation-factor=#{n}"]
+end

--- a/lib/git/commands/rev_list.ex
+++ b/lib/git/commands/rev_list.ex
@@ -1,0 +1,165 @@
+defmodule Git.Commands.RevList do
+  @moduledoc """
+  Implements the `Git.Command` behaviour for `git rev-list`.
+
+  Lists commit objects in reverse chronological order. Supports counting,
+  left-right comparison, ancestry filtering, and various commit-limiting
+  options.
+  """
+
+  @behaviour Git.Command
+
+  @mode_key :__output_mode
+
+  @type t :: %__MODULE__{
+          ref: String.t() | nil,
+          max_count: non_neg_integer() | nil,
+          skip: non_neg_integer() | nil,
+          count: boolean(),
+          left_right: boolean(),
+          ancestry_path: boolean(),
+          first_parent: boolean(),
+          merges: boolean(),
+          no_merges: boolean(),
+          reverse: boolean(),
+          since: String.t() | nil,
+          until_date: String.t() | nil,
+          author: String.t() | nil,
+          all: boolean(),
+          objects: boolean(),
+          no_walk: boolean()
+        }
+
+  defstruct ref: nil,
+            max_count: nil,
+            skip: nil,
+            count: false,
+            left_right: false,
+            ancestry_path: false,
+            first_parent: false,
+            merges: false,
+            no_merges: false,
+            reverse: false,
+            since: nil,
+            until_date: nil,
+            author: nil,
+            all: false,
+            objects: false,
+            no_walk: false
+
+  @doc """
+  Builds the argument list for `git rev-list`.
+
+  ## Examples
+
+      iex> Git.Commands.RevList.args(%Git.Commands.RevList{ref: "HEAD"})
+      ["rev-list", "HEAD"]
+
+      iex> Git.Commands.RevList.args(%Git.Commands.RevList{ref: "HEAD", count: true})
+      ["rev-list", "--count", "HEAD"]
+
+      iex> Git.Commands.RevList.args(%Git.Commands.RevList{ref: "main..feature", left_right: true, count: true})
+      ["rev-list", "--count", "--left-right", "main..feature"]
+
+      iex> Git.Commands.RevList.args(%Git.Commands.RevList{ref: "HEAD", max_count: 5})
+      ["rev-list", "--max-count=5", "HEAD"]
+
+      iex> Git.Commands.RevList.args(%Git.Commands.RevList{all: true})
+      ["rev-list", "--all"]
+
+  """
+  @spec args(t()) :: [String.t()]
+  @impl true
+  def args(%__MODULE__{} = command) do
+    set_output_mode(command)
+    base = ["rev-list"]
+
+    base
+    |> maybe_add("--max-count=", command.max_count)
+    |> maybe_add("--skip=", command.skip)
+    |> maybe_add_flag(command.count, "--count")
+    |> maybe_add_flag(command.left_right, "--left-right")
+    |> maybe_add_flag(command.ancestry_path, "--ancestry-path")
+    |> maybe_add_flag(command.first_parent, "--first-parent")
+    |> maybe_add_flag(command.merges, "--merges")
+    |> maybe_add_flag(command.no_merges, "--no-merges")
+    |> maybe_add_flag(command.reverse, "--reverse")
+    |> maybe_add("--since=", command.since)
+    |> maybe_add("--until=", command.until_date)
+    |> maybe_add("--author=", command.author)
+    |> maybe_add_flag(command.all, "--all")
+    |> maybe_add_flag(command.objects, "--objects")
+    |> maybe_add_flag(command.no_walk, "--no-walk")
+    |> maybe_add_ref(command.ref)
+  end
+
+  @doc """
+  Parses the output of `git rev-list`.
+
+  The output mode depends on the flags used:
+
+    * Default: returns `{:ok, [String.t()]}` with a list of SHAs
+    * With `count: true`: returns `{:ok, integer()}`
+    * With `left_right: true` and `count: true`: returns
+      `{:ok, %{left: integer(), right: integer()}}`
+  """
+  @spec parse_output(String.t(), non_neg_integer()) ::
+          {:ok, [String.t()] | integer() | map()} | {:error, {String.t(), non_neg_integer()}}
+  @impl true
+  def parse_output(stdout, 0) do
+    {:ok, parse_by_mode(stdout, output_mode())}
+  end
+
+  def parse_output(stdout, exit_code), do: {:error, {stdout, exit_code}}
+
+  # Determines the output mode based on Process dictionary state.
+  # This is set by the run wrapper before execution.
+  defp output_mode do
+    Process.get(@mode_key, :list)
+  end
+
+  @doc false
+  def set_output_mode(%__MODULE__{} = command) do
+    mode =
+      cond do
+        command.left_right and command.count -> :left_right_count
+        command.count -> :count
+        true -> :list
+      end
+
+    Process.put(@mode_key, mode)
+    command
+  end
+
+  defp parse_by_mode(stdout, :left_right_count) do
+    case String.trim(stdout) |> String.split("\t") do
+      [left, right] ->
+        %{left: String.to_integer(left), right: String.to_integer(right)}
+
+      _ ->
+        %{left: 0, right: 0}
+    end
+  end
+
+  defp parse_by_mode(stdout, :count) do
+    case String.trim(stdout) do
+      "" -> 0
+      n -> String.to_integer(n)
+    end
+  end
+
+  defp parse_by_mode(stdout, :list) do
+    stdout
+    |> String.split("\n", trim: true)
+    |> Enum.map(&String.trim/1)
+  end
+
+  defp maybe_add(args, _flag, nil), do: args
+  defp maybe_add(args, flag, value), do: args ++ ["#{flag}#{value}"]
+
+  defp maybe_add_flag(args, true, flag), do: args ++ [flag]
+  defp maybe_add_flag(args, false, _flag), do: args
+
+  defp maybe_add_ref(args, nil), do: args
+  defp maybe_add_ref(args, ref), do: args ++ [ref]
+end

--- a/lib/git/commands/sparse_checkout.ex
+++ b/lib/git/commands/sparse_checkout.ex
@@ -1,0 +1,155 @@
+defmodule Git.Commands.SparseCheckout do
+  @moduledoc """
+  Implements the `Git.Command` behaviour for `git sparse-checkout`.
+
+  Supports initializing, setting, adding, listing, disabling, reapplying,
+  and checking rules for sparse-checkout.
+  """
+
+  @behaviour Git.Command
+
+  @type t :: %__MODULE__{
+          init: boolean(),
+          set: [String.t()],
+          add: [String.t()],
+          list: boolean(),
+          disable: boolean(),
+          reapply: boolean(),
+          check_rules: boolean(),
+          cone: boolean(),
+          no_cone: boolean(),
+          sparse_index: boolean(),
+          no_sparse_index: boolean()
+        }
+
+  defstruct init: false,
+            set: [],
+            add: [],
+            list: true,
+            disable: false,
+            reapply: false,
+            check_rules: false,
+            cone: false,
+            no_cone: false,
+            sparse_index: false,
+            no_sparse_index: false
+
+  # Process dictionary key used to communicate the operation mode from args/1
+  # to parse_output/2. Both are called from the same process inside
+  # Git.Command.run/3, so this is safe even with async tests.
+  @mode_key :__git_sparse_checkout_mode__
+
+  @doc """
+  Returns the argument list for `git sparse-checkout`.
+
+  - If `:init` is true, builds `git sparse-checkout init [--cone] [--sparse-index]`.
+  - If `:set` is non-empty, builds `git sparse-checkout set [--cone] [--no-cone] <patterns...>`.
+  - If `:add` is non-empty, builds `git sparse-checkout add [--cone] [--no-cone] <patterns...>`.
+  - If `:disable` is true, builds `git sparse-checkout disable`.
+  - If `:reapply` is true, builds `git sparse-checkout reapply`.
+  - If `:check_rules` is true, builds `git sparse-checkout check-rules`.
+  - Otherwise, lists current patterns with `git sparse-checkout list`.
+
+  ## Examples
+
+      iex> Git.Commands.SparseCheckout.args(%Git.Commands.SparseCheckout{})
+      ["sparse-checkout", "list"]
+
+      iex> Git.Commands.SparseCheckout.args(%Git.Commands.SparseCheckout{init: true, cone: true})
+      ["sparse-checkout", "init", "--cone"]
+
+      iex> Git.Commands.SparseCheckout.args(%Git.Commands.SparseCheckout{set: ["src/", "docs/"], cone: true})
+      ["sparse-checkout", "set", "--cone", "src/", "docs/"]
+
+      iex> Git.Commands.SparseCheckout.args(%Git.Commands.SparseCheckout{add: ["tests/"]})
+      ["sparse-checkout", "add", "tests/"]
+
+      iex> Git.Commands.SparseCheckout.args(%Git.Commands.SparseCheckout{disable: true})
+      ["sparse-checkout", "disable"]
+
+      iex> Git.Commands.SparseCheckout.args(%Git.Commands.SparseCheckout{reapply: true})
+      ["sparse-checkout", "reapply"]
+
+  """
+  @spec args(t()) :: [String.t()]
+  @impl true
+  def args(%__MODULE__{init: true} = command) do
+    Process.put(@mode_key, :mutation)
+
+    ["sparse-checkout", "init"]
+    |> maybe_add_flag(command.cone, "--cone")
+    |> maybe_add_flag(command.no_cone, "--no-cone")
+    |> maybe_add_flag(command.sparse_index, "--sparse-index")
+    |> maybe_add_flag(command.no_sparse_index, "--no-sparse-index")
+  end
+
+  def args(%__MODULE__{set: patterns} = command) when patterns != [] do
+    Process.put(@mode_key, :mutation)
+
+    ["sparse-checkout", "set"]
+    |> maybe_add_flag(command.cone, "--cone")
+    |> maybe_add_flag(command.no_cone, "--no-cone")
+    |> Kernel.++(patterns)
+  end
+
+  def args(%__MODULE__{add: patterns} = command) when patterns != [] do
+    Process.put(@mode_key, :mutation)
+
+    ["sparse-checkout", "add"]
+    |> maybe_add_flag(command.cone, "--cone")
+    |> maybe_add_flag(command.no_cone, "--no-cone")
+    |> Kernel.++(patterns)
+  end
+
+  def args(%__MODULE__{disable: true}) do
+    Process.put(@mode_key, :mutation)
+    ["sparse-checkout", "disable"]
+  end
+
+  def args(%__MODULE__{reapply: true}) do
+    Process.put(@mode_key, :mutation)
+    ["sparse-checkout", "reapply"]
+  end
+
+  def args(%__MODULE__{check_rules: true}) do
+    Process.put(@mode_key, :mutation)
+    ["sparse-checkout", "check-rules"]
+  end
+
+  def args(%__MODULE__{}) do
+    Process.put(@mode_key, :list)
+    ["sparse-checkout", "list"]
+  end
+
+  @doc """
+  Parses the output of `git sparse-checkout`.
+
+  For list operations (exit 0), returns `{:ok, [pattern]}` with one pattern
+  per line. For all mutation operations (exit 0), returns `{:ok, :done}`.
+  On failure, returns `{:error, {stdout, exit_code}}`.
+  """
+  @spec parse_output(String.t(), non_neg_integer()) ::
+          {:ok, [String.t()]} | {:ok, :done} | {:error, {String.t(), non_neg_integer()}}
+  @impl true
+  def parse_output(stdout, 0) do
+    mode = Process.get(@mode_key, :list)
+
+    case mode do
+      :mutation ->
+        {:ok, :done}
+
+      :list ->
+        patterns =
+          stdout
+          |> String.split("\n", trim: true)
+          |> Enum.map(&String.trim/1)
+
+        {:ok, patterns}
+    end
+  end
+
+  def parse_output(stdout, exit_code), do: {:error, {stdout, exit_code}}
+
+  defp maybe_add_flag(args, false, _flag), do: args
+  defp maybe_add_flag(args, true, flag), do: args ++ [flag]
+end

--- a/lib/git/repo.ex
+++ b/lib/git/repo.ex
@@ -589,4 +589,93 @@ defmodule Git.Repo do
   def ls_tree(%__MODULE__{} = repo, opts \\ []) do
     Git.ls_tree(Keyword.put(opts, :config, repo.config))
   end
+
+  @doc """
+  Runs `git range-diff` on the repository.
+
+  See `Git.range_diff/1` for available options.
+  """
+  @spec range_diff(t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def range_diff(%__MODULE__{} = repo, opts \\ []) do
+    Git.range_diff(Keyword.put(opts, :config, repo.config))
+  end
+
+  @doc """
+  Runs `git sparse-checkout` on the repository.
+
+  See `Git.sparse_checkout/1` for available options.
+  """
+  @spec sparse_checkout(t(), keyword()) ::
+          {:ok, [String.t()]} | {:ok, :done} | {:error, term()}
+  def sparse_checkout(%__MODULE__{} = repo, opts \\ []) do
+    Git.sparse_checkout(Keyword.put(opts, :config, repo.config))
+  end
+
+  @doc """
+  Runs `git rev-list` on the repository.
+
+  See `Git.rev_list/1` for available options.
+  """
+  @spec rev_list(t(), keyword()) ::
+          {:ok, [String.t()] | integer() | map()} | {:error, term()}
+  def rev_list(%__MODULE__{} = repo, opts \\ []) do
+    Git.rev_list(Keyword.put(opts, :config, repo.config))
+  end
+
+  @doc """
+  Runs `git merge-base` on the repository.
+
+  See `Git.merge_base/1` for available options.
+  """
+  @spec merge_base(t(), keyword()) ::
+          {:ok, String.t() | boolean() | [String.t()]} | {:error, term()}
+  def merge_base(%__MODULE__{} = repo, opts \\ []) do
+    Git.merge_base(Keyword.put(opts, :config, repo.config))
+  end
+
+  @doc """
+  Runs `git cherry` on the repository.
+
+  See `Git.cherry/1` for available options.
+  """
+  @spec cherry(t(), keyword()) :: {:ok, [Git.CherryEntry.t()]} | {:error, term()}
+  def cherry(%__MODULE__{} = repo, opts \\ []) do
+    Git.cherry(Keyword.put(opts, :config, repo.config))
+  end
+
+  @doc """
+  Runs `git cat-file` on the repository.
+
+  See `Git.cat_file/2` for available options.
+  """
+  @spec cat_file(t(), String.t(), keyword()) ::
+          {:ok, atom()}
+          | {:ok, integer()}
+          | {:ok, String.t()}
+          | {:ok, boolean()}
+          | {:error, term()}
+  def cat_file(%__MODULE__{} = repo, object, opts \\ []) do
+    Git.cat_file(object, Keyword.put(opts, :config, repo.config))
+  end
+
+  @doc """
+  Runs `git check-ignore` on the repository.
+
+  See `Git.check_ignore/1` for available options.
+  """
+  @spec check_ignore(t(), keyword()) :: {:ok, [String.t()] | [map()]} | {:error, term()}
+  def check_ignore(%__MODULE__{} = repo, opts \\ []) do
+    Git.check_ignore(Keyword.put(opts, :config, repo.config))
+  end
+
+  @doc """
+  Runs `git notes` on the repository.
+
+  See `Git.notes/1` for available options.
+  """
+  @spec notes(t(), keyword()) ::
+          {:ok, [map()]} | {:ok, String.t()} | {:ok, :done} | {:error, term()}
+  def notes(%__MODULE__{} = repo, opts \\ []) do
+    Git.notes(Keyword.put(opts, :config, repo.config))
+  end
 end

--- a/test/git/commands/cat_file_test.exs
+++ b/test/git/commands/cat_file_test.exs
@@ -1,0 +1,114 @@
+defmodule Git.CatFileTest do
+  use ExUnit.Case, async: true
+
+  alias Git.Commands.CatFile
+  alias Git.Config
+
+  @env [
+    {"GIT_AUTHOR_NAME", "Test User"},
+    {"GIT_AUTHOR_EMAIL", "test@test.com"},
+    {"GIT_COMMITTER_NAME", "Test User"},
+    {"GIT_COMMITTER_EMAIL", "test@test.com"}
+  ]
+
+  defp setup_repo do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "git_cat_file_test_#{:erlang.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    cfg = Config.new(working_dir: tmp_dir, env: @env)
+    {:ok, :done} = Git.init(config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.name", set_value: "Test User", config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.email", set_value: "test@test.com", config: cfg)
+    {:ok, _} = Git.commit("initial", allow_empty: true, config: cfg)
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+    {tmp_dir, cfg}
+  end
+
+  describe "args/1" do
+    test "builds args for type query" do
+      assert CatFile.args(%CatFile{object: "HEAD", type: true}) ==
+               ["cat-file", "-t", "HEAD"]
+    end
+
+    test "builds args for size query" do
+      assert CatFile.args(%CatFile{object: "HEAD", size: true}) ==
+               ["cat-file", "-s", "HEAD"]
+    end
+
+    test "builds args for pretty-print" do
+      assert CatFile.args(%CatFile{object: "HEAD", print: true}) ==
+               ["cat-file", "-p", "HEAD"]
+    end
+
+    test "builds args for exists check" do
+      assert CatFile.args(%CatFile{object: "HEAD", exists: true}) ==
+               ["cat-file", "-e", "HEAD"]
+    end
+
+    test "builds args for textconv" do
+      assert CatFile.args(%CatFile{object: "HEAD", textconv: true}) ==
+               ["cat-file", "--textconv", "HEAD"]
+    end
+
+    test "builds args for filters" do
+      assert CatFile.args(%CatFile{object: "HEAD", filters: true}) ==
+               ["cat-file", "--filters", "HEAD"]
+    end
+
+    test "defaults to pretty-print when no flag set" do
+      assert CatFile.args(%CatFile{object: "HEAD"}) ==
+               ["cat-file", "-p", "HEAD"]
+    end
+  end
+
+  describe "cat-file -t (type)" do
+    test "returns :commit for a commit object" do
+      {_tmp_dir, cfg} = setup_repo()
+
+      {:ok, type} = Git.cat_file("HEAD", type: true, config: cfg)
+      assert type == :commit
+    end
+  end
+
+  describe "cat-file -s (size)" do
+    test "returns an integer size for a commit object" do
+      {_tmp_dir, cfg} = setup_repo()
+
+      {:ok, size} = Git.cat_file("HEAD", size: true, config: cfg)
+      assert is_integer(size)
+      assert size > 0
+    end
+  end
+
+  describe "cat-file -p (print)" do
+    test "returns commit content as a string" do
+      {_tmp_dir, cfg} = setup_repo()
+
+      {:ok, content} = Git.cat_file("HEAD", print: true, config: cfg)
+      assert is_binary(content)
+      assert content =~ "initial"
+    end
+  end
+
+  describe "cat-file -e (exists)" do
+    test "returns true for an existing object" do
+      {_tmp_dir, cfg} = setup_repo()
+
+      {:ok, exists} = Git.cat_file("HEAD", exists: true, config: cfg)
+      assert exists == true
+    end
+
+    test "returns false for a non-existing object" do
+      {_tmp_dir, cfg} = setup_repo()
+
+      {:ok, exists} =
+        Git.cat_file("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", exists: true, config: cfg)
+
+      assert exists == false
+    end
+  end
+end

--- a/test/git/commands/check_ignore_test.exs
+++ b/test/git/commands/check_ignore_test.exs
@@ -1,0 +1,98 @@
+defmodule Git.CheckIgnoreTest do
+  use ExUnit.Case, async: true
+
+  alias Git.Commands.CheckIgnore
+  alias Git.Config
+
+  @env [
+    {"GIT_AUTHOR_NAME", "Test User"},
+    {"GIT_AUTHOR_EMAIL", "test@test.com"},
+    {"GIT_COMMITTER_NAME", "Test User"},
+    {"GIT_COMMITTER_EMAIL", "test@test.com"}
+  ]
+
+  defp setup_repo do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "git_check_ignore_test_#{:erlang.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    cfg = Config.new(working_dir: tmp_dir, env: @env)
+    {:ok, :done} = Git.init(config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.name", set_value: "Test User", config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.email", set_value: "test@test.com", config: cfg)
+    {:ok, _} = Git.commit("initial", allow_empty: true, config: cfg)
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+    {tmp_dir, cfg}
+  end
+
+  describe "args/1" do
+    test "builds args with paths" do
+      assert CheckIgnore.args(%CheckIgnore{paths: ["build/", "tmp.log"]}) ==
+               ["check-ignore", "build/", "tmp.log"]
+    end
+
+    test "builds args with verbose flag" do
+      assert CheckIgnore.args(%CheckIgnore{paths: ["foo"], verbose: true}) ==
+               ["check-ignore", "-v", "foo"]
+    end
+
+    test "builds args with verbose and non_matching" do
+      assert CheckIgnore.args(%CheckIgnore{paths: ["foo"], verbose: true, non_matching: true}) ==
+               ["check-ignore", "-v", "-n", "foo"]
+    end
+
+    test "builds args with no_index flag" do
+      assert CheckIgnore.args(%CheckIgnore{paths: ["foo"], no_index: true}) ==
+               ["check-ignore", "--no-index", "foo"]
+    end
+
+    test "builds args with quiet flag" do
+      assert CheckIgnore.args(%CheckIgnore{paths: ["foo"], quiet: true}) ==
+               ["check-ignore", "-q", "foo"]
+    end
+  end
+
+  describe "check-ignore with ignored files" do
+    test "returns list of ignored paths" do
+      {tmp_dir, cfg} = setup_repo()
+
+      File.write!(Path.join(tmp_dir, ".gitignore"), "*.log\nbuild/\n")
+      File.write!(Path.join(tmp_dir, "app.log"), "log content")
+      File.mkdir_p!(Path.join(tmp_dir, "build"))
+
+      {:ok, paths} = Git.check_ignore(paths: ["app.log", "build/"], config: cfg)
+      assert "app.log" in paths
+      assert "build/" in paths
+    end
+
+    test "returns empty list when no paths are ignored" do
+      {tmp_dir, cfg} = setup_repo()
+
+      File.write!(Path.join(tmp_dir, ".gitignore"), "*.log\n")
+      File.write!(Path.join(tmp_dir, "main.ex"), "code")
+
+      {:ok, paths} = Git.check_ignore(paths: ["main.ex"], config: cfg)
+      assert paths == []
+    end
+  end
+
+  describe "check-ignore --verbose" do
+    test "returns verbose entries with source, line_number, pattern, and path" do
+      {tmp_dir, cfg} = setup_repo()
+
+      File.write!(Path.join(tmp_dir, ".gitignore"), "*.log\nbuild/\n")
+      File.write!(Path.join(tmp_dir, "app.log"), "log content")
+
+      {:ok, entries} = Git.check_ignore(paths: ["app.log"], verbose: true, config: cfg)
+      assert length(entries) == 1
+      [entry] = entries
+      assert entry.path == "app.log"
+      assert entry.pattern == "*.log"
+      assert entry.line_number == 1
+      assert entry.source =~ ".gitignore"
+    end
+  end
+end

--- a/test/git/commands/cherry_test.exs
+++ b/test/git/commands/cherry_test.exs
@@ -1,0 +1,123 @@
+defmodule Git.Commands.CherryTest do
+  use ExUnit.Case, async: true
+
+  alias Git.CherryEntry
+  alias Git.Commands.Cherry
+  alias Git.Config
+
+  @env [
+    {"GIT_AUTHOR_NAME", "Test User"},
+    {"GIT_AUTHOR_EMAIL", "test@test.com"},
+    {"GIT_COMMITTER_NAME", "Test User"},
+    {"GIT_COMMITTER_EMAIL", "test@test.com"}
+  ]
+
+  defp setup_repo(name) do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "git_#{name}_test_#{:erlang.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    cfg = Config.new(working_dir: tmp_dir, env: @env)
+    {:ok, :done} = Git.init(config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.name", set_value: "Test User", config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.email", set_value: "test@test.com", config: cfg)
+    {:ok, _} = Git.commit("initial", allow_empty: true, config: cfg)
+    {tmp_dir, cfg}
+  end
+
+  setup do
+    {tmp_dir, cfg} = setup_repo("cherry")
+
+    # Create feature branch with unique commits
+    System.cmd("git", ["checkout", "-b", "feature"], cd: tmp_dir, env: @env)
+
+    File.write!(Path.join(tmp_dir, "a.txt"), "a content\n")
+    {:ok, :done} = Git.add(all: true, config: cfg)
+    {:ok, _} = Git.commit("add a.txt", config: cfg)
+
+    File.write!(Path.join(tmp_dir, "b.txt"), "b content\n")
+    {:ok, :done} = Git.add(all: true, config: cfg)
+    {:ok, _} = Git.commit("add b.txt", config: cfg)
+
+    # Go back to main
+    System.cmd("git", ["checkout", "main"], cd: tmp_dir, env: @env)
+
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+    %{tmp_dir: tmp_dir, config: cfg}
+  end
+
+  describe "args/1" do
+    test "builds basic args with upstream" do
+      assert Cherry.args(%Cherry{upstream: "main"}) == ["cherry", "main"]
+    end
+
+    test "builds args with verbose" do
+      assert Cherry.args(%Cherry{upstream: "main", verbose: true}) ==
+               ["cherry", "-v", "main"]
+    end
+
+    test "builds args with upstream and head" do
+      assert Cherry.args(%Cherry{upstream: "main", head: "feature"}) ==
+               ["cherry", "main", "feature"]
+    end
+
+    test "builds args with upstream, head, and limit" do
+      assert Cherry.args(%Cherry{upstream: "main", head: "feature", limit: "v1.0"}) ==
+               ["cherry", "main", "feature", "v1.0"]
+    end
+  end
+
+  describe "git cherry integration" do
+    test "finds unapplied commits between branches", %{config: config} do
+      {:ok, entries} =
+        Git.cherry(upstream: "main", head: "feature", config: config)
+
+      assert is_list(entries)
+      assert length(entries) == 2
+      assert Enum.all?(entries, fn e -> %CherryEntry{} = e end)
+      # Both commits are unique to feature, so not applied upstream
+      assert Enum.all?(entries, fn e -> e.applied == false end)
+    end
+
+    test "verbose mode includes subjects", %{config: config} do
+      {:ok, entries} =
+        Git.cherry(upstream: "main", head: "feature", verbose: true, config: config)
+
+      assert length(entries) == 2
+      subjects = Enum.map(entries, & &1.subject)
+      assert "add a.txt" in subjects
+      assert "add b.txt" in subjects
+    end
+
+    test "applied detection after cherry-pick", %{config: config, tmp_dir: tmp_dir} do
+      # Add a third commit on feature so we have more to work with
+      System.cmd("git", ["checkout", "feature"], cd: tmp_dir, env: @env)
+      File.write!(Path.join(tmp_dir, "c.txt"), "c content\n")
+      {:ok, :done} = Git.add(all: true, config: config)
+      {:ok, _} = Git.commit("add c.txt", config: config)
+
+      # Get the SHA of the middle feature commit (add b.txt)
+      {sha, 0} = System.cmd("git", ["rev-parse", "feature~1"], cd: tmp_dir)
+      sha = String.trim(sha)
+
+      # Cherry-pick it onto main
+      System.cmd("git", ["checkout", "main"], cd: tmp_dir, env: @env)
+      {_, 0} = System.cmd("git", ["cherry-pick", sha], cd: tmp_dir, env: @env)
+
+      {:ok, entries} =
+        Git.cherry(upstream: "main", head: "feature", config: config)
+
+      assert length(entries) == 3
+
+      # The cherry-picked commit should be marked as applied
+      applied = Enum.filter(entries, & &1.applied)
+      not_applied = Enum.reject(entries, & &1.applied)
+      assert length(applied) == 1
+      assert length(not_applied) == 2
+    end
+  end
+end

--- a/test/git/commands/merge_base_test.exs
+++ b/test/git/commands/merge_base_test.exs
@@ -1,0 +1,132 @@
+defmodule Git.Commands.MergeBaseTest do
+  use ExUnit.Case, async: true
+
+  alias Git.Commands.MergeBase
+  alias Git.Config
+
+  @env [
+    {"GIT_AUTHOR_NAME", "Test User"},
+    {"GIT_AUTHOR_EMAIL", "test@test.com"},
+    {"GIT_COMMITTER_NAME", "Test User"},
+    {"GIT_COMMITTER_EMAIL", "test@test.com"}
+  ]
+
+  defp setup_repo(name) do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "git_#{name}_test_#{:erlang.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    cfg = Config.new(working_dir: tmp_dir, env: @env)
+    {:ok, :done} = Git.init(config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.name", set_value: "Test User", config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.email", set_value: "test@test.com", config: cfg)
+    {:ok, _} = Git.commit("initial", allow_empty: true, config: cfg)
+    {tmp_dir, cfg}
+  end
+
+  setup do
+    {tmp_dir, cfg} = setup_repo("merge_base")
+
+    # Create a branching history:
+    # initial -> second (main) -> third (main)
+    #         \-> feature-1 -> feature-2 (feature)
+    {:ok, _} = Git.commit("second", allow_empty: true, config: cfg)
+
+    # Get the initial commit SHA for branching
+    {initial_sha, 0} = System.cmd("git", ["rev-parse", "HEAD~1"], cd: tmp_dir)
+    initial_sha = String.trim(initial_sha)
+
+    System.cmd("git", ["checkout", "-b", "feature", initial_sha],
+      cd: tmp_dir,
+      env: @env
+    )
+
+    {:ok, _} = Git.commit("feature-1", allow_empty: true, config: cfg)
+    {:ok, _} = Git.commit("feature-2", allow_empty: true, config: cfg)
+
+    # Go back to main for the third commit
+    System.cmd("git", ["checkout", "main"], cd: tmp_dir, env: @env)
+    {:ok, _} = Git.commit("third", allow_empty: true, config: cfg)
+
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+    %{tmp_dir: tmp_dir, config: cfg, initial_sha: initial_sha}
+  end
+
+  describe "args/1" do
+    test "builds basic args with two commits" do
+      assert MergeBase.args(%MergeBase{commits: ["main", "feature"]}) ==
+               ["merge-base", "main", "feature"]
+    end
+
+    test "builds args with is_ancestor" do
+      assert MergeBase.args(%MergeBase{commits: ["main", "feature"], is_ancestor: true}) ==
+               ["merge-base", "--is-ancestor", "main", "feature"]
+    end
+
+    test "builds args with all" do
+      assert MergeBase.args(%MergeBase{commits: ["main", "feature"], all: true}) ==
+               ["merge-base", "--all", "main", "feature"]
+    end
+
+    test "builds args with octopus" do
+      assert MergeBase.args(%MergeBase{commits: ["a", "b", "c"], octopus: true}) ==
+               ["merge-base", "--octopus", "a", "b", "c"]
+    end
+
+    test "builds args with independent" do
+      assert MergeBase.args(%MergeBase{commits: ["a", "b", "c"], independent: true}) ==
+               ["merge-base", "--independent", "a", "b", "c"]
+    end
+
+    test "builds args with fork_point" do
+      assert MergeBase.args(%MergeBase{commits: ["main", "feature"], fork_point: true}) ==
+               ["merge-base", "--fork-point", "main", "feature"]
+    end
+  end
+
+  describe "git merge-base integration" do
+    test "finds common ancestor", %{config: config, initial_sha: initial_sha} do
+      {:ok, sha} = Git.merge_base(commits: ["main", "feature"], config: config)
+
+      assert sha == initial_sha
+    end
+
+    test "is_ancestor returns true when ancestor", %{config: config, initial_sha: initial_sha} do
+      {:ok, result} =
+        Git.merge_base(
+          commits: [initial_sha, "main"],
+          is_ancestor: true,
+          config: config
+        )
+
+      assert result == true
+    end
+
+    test "is_ancestor returns false when not ancestor", %{config: config} do
+      {:ok, result} =
+        Git.merge_base(
+          commits: ["main", "feature"],
+          is_ancestor: true,
+          config: config
+        )
+
+      assert result == false
+    end
+
+    test "all returns list of merge bases", %{config: config, initial_sha: initial_sha} do
+      {:ok, shas} =
+        Git.merge_base(
+          commits: ["main", "feature"],
+          all: true,
+          config: config
+        )
+
+      assert is_list(shas)
+      assert initial_sha in shas
+    end
+  end
+end

--- a/test/git/commands/notes_test.exs
+++ b/test/git/commands/notes_test.exs
@@ -1,0 +1,123 @@
+defmodule Git.NotesTest do
+  use ExUnit.Case, async: true
+
+  alias Git.Commands.Notes
+  alias Git.Config
+
+  @env [
+    {"GIT_AUTHOR_NAME", "Test User"},
+    {"GIT_AUTHOR_EMAIL", "test@test.com"},
+    {"GIT_COMMITTER_NAME", "Test User"},
+    {"GIT_COMMITTER_EMAIL", "test@test.com"}
+  ]
+
+  defp setup_repo do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "git_notes_test_#{:erlang.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    cfg = Config.new(working_dir: tmp_dir, env: @env)
+    {:ok, :done} = Git.init(config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.name", set_value: "Test User", config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.email", set_value: "test@test.com", config: cfg)
+    {:ok, _} = Git.commit("initial", allow_empty: true, config: cfg)
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+    {tmp_dir, cfg}
+  end
+
+  describe "args/1" do
+    test "builds args for list (default)" do
+      assert Notes.args(%Notes{}) == ["notes", "list"]
+    end
+
+    test "builds args for show" do
+      assert Notes.args(%Notes{show: "HEAD"}) == ["notes", "show", "HEAD"]
+    end
+
+    test "builds args for add with message" do
+      assert Notes.args(%Notes{add: true, message: "my note", ref: "HEAD"}) ==
+               ["notes", "add", "-m", "my note", "HEAD"]
+    end
+
+    test "builds args for add with force" do
+      assert Notes.args(%Notes{add: true, message: "note", ref: "HEAD", force: true}) ==
+               ["notes", "add", "-f", "-m", "note", "HEAD"]
+    end
+
+    test "builds args for append" do
+      assert Notes.args(%Notes{append: true, message: "more", ref: "HEAD"}) ==
+               ["notes", "append", "-m", "more", "HEAD"]
+    end
+
+    test "builds args for remove" do
+      assert Notes.args(%Notes{remove: "HEAD"}) == ["notes", "remove", "HEAD"]
+    end
+
+    test "builds args for prune" do
+      assert Notes.args(%Notes{prune: true}) == ["notes", "prune"]
+    end
+
+    test "builds args with notes_ref" do
+      assert Notes.args(%Notes{notes_ref: "custom"}) == ["notes", "--ref=custom", "list"]
+    end
+  end
+
+  describe "notes add and show" do
+    test "adds a note and shows it" do
+      {_tmp_dir, cfg} = setup_repo()
+
+      {:ok, :done} = Git.notes(add: true, message: "review passed", ref: "HEAD", config: cfg)
+      {:ok, content} = Git.notes(show: "HEAD", config: cfg)
+      assert content == "review passed"
+    end
+  end
+
+  describe "notes list" do
+    test "lists notes after adding one" do
+      {_tmp_dir, cfg} = setup_repo()
+
+      {:ok, :done} = Git.notes(add: true, message: "a note", ref: "HEAD", config: cfg)
+      {:ok, entries} = Git.notes(config: cfg)
+      assert length(entries) == 1
+      [entry] = entries
+      assert is_binary(entry.note_sha)
+      assert is_binary(entry.commit_sha)
+    end
+
+    test "returns empty list when no notes exist" do
+      {_tmp_dir, cfg} = setup_repo()
+
+      {:ok, entries} = Git.notes(config: cfg)
+      assert entries == []
+    end
+  end
+
+  describe "notes remove" do
+    test "removes a note" do
+      {_tmp_dir, cfg} = setup_repo()
+
+      {:ok, :done} = Git.notes(add: true, message: "temp note", ref: "HEAD", config: cfg)
+      {:ok, entries_before} = Git.notes(config: cfg)
+      assert length(entries_before) == 1
+
+      {:ok, :done} = Git.notes(remove: "HEAD", config: cfg)
+      {:ok, entries_after} = Git.notes(config: cfg)
+      assert entries_after == []
+    end
+  end
+
+  describe "notes append" do
+    test "appends to an existing note" do
+      {_tmp_dir, cfg} = setup_repo()
+
+      {:ok, :done} = Git.notes(add: true, message: "first line", ref: "HEAD", config: cfg)
+      {:ok, :done} = Git.notes(append: true, message: "second line", ref: "HEAD", config: cfg)
+      {:ok, content} = Git.notes(show: "HEAD", config: cfg)
+      assert content =~ "first line"
+      assert content =~ "second line"
+    end
+  end
+end

--- a/test/git/commands/range_diff_test.exs
+++ b/test/git/commands/range_diff_test.exs
@@ -1,0 +1,165 @@
+defmodule Git.RangeDiffTest do
+  use ExUnit.Case, async: true
+
+  alias Git.Commands.RangeDiff
+  alias Git.Config
+
+  @env [
+    {"GIT_AUTHOR_NAME", "Test User"},
+    {"GIT_AUTHOR_EMAIL", "test@test.com"},
+    {"GIT_COMMITTER_NAME", "Test User"},
+    {"GIT_COMMITTER_EMAIL", "test@test.com"}
+  ]
+
+  defp setup_repo do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "git_range_diff_test_#{:erlang.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    cfg = Config.new(working_dir: tmp_dir, env: @env)
+    {:ok, :done} = Git.init(config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.name", set_value: "Test User", config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.email", set_value: "test@test.com", config: cfg)
+    {:ok, _} = Git.commit("initial", allow_empty: true, config: cfg)
+    {tmp_dir, cfg}
+  end
+
+  setup do
+    {tmp_dir, config} = setup_repo()
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+    %{tmp_dir: tmp_dir, config: config}
+  end
+
+  describe "Git.Commands.RangeDiff args/1" do
+    test "builds args for two-range form" do
+      assert RangeDiff.args(%RangeDiff{range1: "main..topic-v1", range2: "main..topic-v2"}) ==
+               ["range-diff", "main..topic-v1", "main..topic-v2"]
+    end
+
+    test "builds args for three-arg form" do
+      assert RangeDiff.args(%RangeDiff{rev1: "main", rev2: "topic-v1", rev3: "topic-v2"}) ==
+               ["range-diff", "main", "topic-v1", "topic-v2"]
+    end
+
+    test "builds args with stat flag" do
+      assert RangeDiff.args(%RangeDiff{range1: "a..b", range2: "a..c", stat: true}) ==
+               ["range-diff", "--stat", "a..b", "a..c"]
+    end
+
+    test "builds args with no_patch flag" do
+      assert RangeDiff.args(%RangeDiff{range1: "a..b", range2: "a..c", no_patch: true}) ==
+               ["range-diff", "--no-patch", "a..b", "a..c"]
+    end
+
+    test "builds args with creation_factor" do
+      assert RangeDiff.args(%RangeDiff{range1: "a..b", range2: "a..c", creation_factor: 50}) ==
+               ["range-diff", "--creation-factor=50", "a..b", "a..c"]
+    end
+
+    test "builds args with no_dual_color flag" do
+      assert RangeDiff.args(%RangeDiff{range1: "a..b", range2: "a..c", no_dual_color: true}) ==
+               ["range-diff", "--no-dual-color", "a..b", "a..c"]
+    end
+
+    test "builds args with left_only flag" do
+      assert RangeDiff.args(%RangeDiff{range1: "a..b", range2: "a..c", left_only: true}) ==
+               ["range-diff", "--left-only", "a..b", "a..c"]
+    end
+
+    test "builds args with right_only flag" do
+      assert RangeDiff.args(%RangeDiff{range1: "a..b", range2: "a..c", right_only: true}) ==
+               ["range-diff", "--right-only", "a..b", "a..c"]
+    end
+
+    test "builds args with no_notes flag" do
+      assert RangeDiff.args(%RangeDiff{range1: "a..b", range2: "a..c", no_notes: true}) ==
+               ["range-diff", "--no-notes", "a..b", "a..c"]
+    end
+
+    test "builds args with multiple flags" do
+      assert RangeDiff.args(%RangeDiff{
+               rev1: "base",
+               rev2: "v1",
+               rev3: "v2",
+               stat: true,
+               no_dual_color: true,
+               creation_factor: 75
+             }) ==
+               [
+                 "range-diff",
+                 "--stat",
+                 "--creation-factor=75",
+                 "--no-dual-color",
+                 "base",
+                 "v1",
+                 "v2"
+               ]
+    end
+  end
+
+  describe "git range-diff integration" do
+    test "compares two versions of a branch", %{tmp_dir: tmp_dir, config: config} do
+      # Create a commit on main
+      File.write!(Path.join(tmp_dir, "base.txt"), "base content\n")
+      {:ok, :done} = Git.add(files: ["base.txt"], config: config)
+      {:ok, _} = Git.commit("add base file", config: config)
+
+      # Create topic-v1 branch with a commit
+      {:ok, _} = Git.checkout(branch: "topic-v1", create: true, config: config)
+      File.write!(Path.join(tmp_dir, "feature.txt"), "feature v1\n")
+      {:ok, :done} = Git.add(files: ["feature.txt"], config: config)
+      {:ok, _} = Git.commit("add feature", config: config)
+
+      # Go back to main and create topic-v2 with similar commit
+      {:ok, _} = Git.checkout(branch: "main", config: config)
+      {:ok, _} = Git.checkout(branch: "topic-v2", create: true, config: config)
+      File.write!(Path.join(tmp_dir, "feature.txt"), "feature v2\n")
+      {:ok, :done} = Git.add(files: ["feature.txt"], config: config)
+      {:ok, _} = Git.commit("add feature", config: config)
+
+      # Run range-diff
+      assert {:ok, output} =
+               Git.range_diff(
+                 range1: "main..topic-v1",
+                 range2: "main..topic-v2",
+                 config: config
+               )
+
+      assert is_binary(output)
+    end
+
+    test "compares using three-arg form", %{tmp_dir: tmp_dir, config: config} do
+      # Create a commit on main
+      File.write!(Path.join(tmp_dir, "base.txt"), "base content\n")
+      {:ok, :done} = Git.add(files: ["base.txt"], config: config)
+      {:ok, _} = Git.commit("add base file", config: config)
+
+      # Create topic-v1 branch with a commit
+      {:ok, _} = Git.checkout(branch: "topic-v1", create: true, config: config)
+      File.write!(Path.join(tmp_dir, "feature.txt"), "feature v1\n")
+      {:ok, :done} = Git.add(files: ["feature.txt"], config: config)
+      {:ok, _} = Git.commit("add feature", config: config)
+
+      # Go back to main and create topic-v2 with similar commit
+      {:ok, _} = Git.checkout(branch: "main", config: config)
+      {:ok, _} = Git.checkout(branch: "topic-v2", create: true, config: config)
+      File.write!(Path.join(tmp_dir, "feature.txt"), "feature v2\n")
+      {:ok, :done} = Git.add(files: ["feature.txt"], config: config)
+      {:ok, _} = Git.commit("add feature", config: config)
+
+      # Run range-diff using three-arg form
+      assert {:ok, output} =
+               Git.range_diff(
+                 rev1: "main",
+                 rev2: "topic-v1",
+                 rev3: "topic-v2",
+                 config: config
+               )
+
+      assert is_binary(output)
+    end
+  end
+end

--- a/test/git/commands/rev_list_test.exs
+++ b/test/git/commands/rev_list_test.exs
@@ -1,0 +1,175 @@
+defmodule Git.Commands.RevListTest do
+  use ExUnit.Case, async: true
+
+  alias Git.Commands.RevList
+  alias Git.Config
+
+  @env [
+    {"GIT_AUTHOR_NAME", "Test User"},
+    {"GIT_AUTHOR_EMAIL", "test@test.com"},
+    {"GIT_COMMITTER_NAME", "Test User"},
+    {"GIT_COMMITTER_EMAIL", "test@test.com"}
+  ]
+
+  defp setup_repo(name) do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "git_#{name}_test_#{:erlang.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    cfg = Config.new(working_dir: tmp_dir, env: @env)
+    {:ok, :done} = Git.init(config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.name", set_value: "Test User", config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.email", set_value: "test@test.com", config: cfg)
+    {:ok, _} = Git.commit("initial", allow_empty: true, config: cfg)
+    {tmp_dir, cfg}
+  end
+
+  setup do
+    {tmp_dir, cfg} = setup_repo("rev_list")
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+    %{tmp_dir: tmp_dir, config: cfg}
+  end
+
+  describe "args/1" do
+    test "builds basic args with ref" do
+      assert RevList.args(%RevList{ref: "HEAD"}) == ["rev-list", "HEAD"]
+    end
+
+    test "builds args with count" do
+      assert RevList.args(%RevList{ref: "HEAD", count: true}) ==
+               ["rev-list", "--count", "HEAD"]
+    end
+
+    test "builds args with left-right and count" do
+      assert RevList.args(%RevList{ref: "main..feature", left_right: true, count: true}) ==
+               ["rev-list", "--count", "--left-right", "main..feature"]
+    end
+
+    test "builds args with max_count" do
+      assert RevList.args(%RevList{ref: "HEAD", max_count: 5}) ==
+               ["rev-list", "--max-count=5", "HEAD"]
+    end
+
+    test "builds args with no_merges" do
+      assert RevList.args(%RevList{ref: "HEAD", no_merges: true}) ==
+               ["rev-list", "--no-merges", "HEAD"]
+    end
+
+    test "builds args with all" do
+      assert RevList.args(%RevList{all: true}) == ["rev-list", "--all"]
+    end
+
+    test "builds args with since and until" do
+      assert RevList.args(%RevList{ref: "HEAD", since: "2024-01-01", until_date: "2024-12-31"}) ==
+               ["rev-list", "--since=2024-01-01", "--until=2024-12-31", "HEAD"]
+    end
+
+    test "builds args with author" do
+      assert RevList.args(%RevList{ref: "HEAD", author: "Test"}) ==
+               ["rev-list", "--author=Test", "HEAD"]
+    end
+
+    test "builds args with skip" do
+      assert RevList.args(%RevList{ref: "HEAD", skip: 3}) ==
+               ["rev-list", "--skip=3", "HEAD"]
+    end
+
+    test "builds args with first_parent" do
+      assert RevList.args(%RevList{ref: "HEAD", first_parent: true}) ==
+               ["rev-list", "--first-parent", "HEAD"]
+    end
+
+    test "builds args with reverse" do
+      assert RevList.args(%RevList{ref: "HEAD", reverse: true}) ==
+               ["rev-list", "--reverse", "HEAD"]
+    end
+
+    test "builds args with ancestry_path" do
+      assert RevList.args(%RevList{ref: "HEAD", ancestry_path: true}) ==
+               ["rev-list", "--ancestry-path", "HEAD"]
+    end
+
+    test "builds args with objects" do
+      assert RevList.args(%RevList{ref: "HEAD", objects: true}) ==
+               ["rev-list", "--objects", "HEAD"]
+    end
+
+    test "builds args with no_walk" do
+      assert RevList.args(%RevList{ref: "HEAD", no_walk: true}) ==
+               ["rev-list", "--no-walk", "HEAD"]
+    end
+  end
+
+  describe "git rev-list integration" do
+    test "lists SHAs", %{config: config} do
+      {:ok, shas} = Git.rev_list(ref: "HEAD", config: config)
+
+      assert is_list(shas)
+      assert length(shas) == 1
+      assert Enum.all?(shas, &String.match?(&1, ~r/^[0-9a-f]{40}$/))
+    end
+
+    test "lists multiple SHAs", %{config: config} do
+      {:ok, _} = Git.commit("second", allow_empty: true, config: config)
+      {:ok, _} = Git.commit("third", allow_empty: true, config: config)
+
+      {:ok, shas} = Git.rev_list(ref: "HEAD", config: config)
+
+      assert length(shas) == 3
+    end
+
+    test "count mode returns integer", %{config: config} do
+      {:ok, _} = Git.commit("second", allow_empty: true, config: config)
+
+      {:ok, count} = Git.rev_list(ref: "HEAD", count: true, config: config)
+
+      assert is_integer(count)
+      assert count == 2
+    end
+
+    test "left-right count with diverged branches", %{config: config, tmp_dir: tmp_dir} do
+      # Create a second commit on main
+      {:ok, _} = Git.commit("second on main", allow_empty: true, config: config)
+
+      # Create a branch from the initial commit
+      System.cmd("git", ["checkout", "-b", "feature", "HEAD~1"],
+        cd: tmp_dir,
+        env: @env
+      )
+
+      {:ok, _} = Git.commit("first on feature", allow_empty: true, config: config)
+      {:ok, _} = Git.commit("second on feature", allow_empty: true, config: config)
+
+      {:ok, result} =
+        Git.rev_list(
+          ref: "main...feature",
+          left_right: true,
+          count: true,
+          config: config
+        )
+
+      assert is_map(result)
+      assert result.left == 1
+      assert result.right == 2
+    end
+
+    test "max_count limits results", %{config: config} do
+      {:ok, _} = Git.commit("second", allow_empty: true, config: config)
+      {:ok, _} = Git.commit("third", allow_empty: true, config: config)
+
+      {:ok, shas} = Git.rev_list(ref: "HEAD", max_count: 2, config: config)
+
+      assert length(shas) == 2
+    end
+
+    test "no_merges excludes merge commits", %{config: config} do
+      {:ok, shas} = Git.rev_list(ref: "HEAD", no_merges: true, config: config)
+
+      assert is_list(shas)
+      assert length(shas) == 1
+    end
+  end
+end

--- a/test/git/commands/sparse_checkout_test.exs
+++ b/test/git/commands/sparse_checkout_test.exs
@@ -1,0 +1,131 @@
+defmodule Git.SparseCheckoutTest do
+  use ExUnit.Case, async: true
+
+  alias Git.Commands.SparseCheckout
+  alias Git.Config
+
+  @env [
+    {"GIT_AUTHOR_NAME", "Test User"},
+    {"GIT_AUTHOR_EMAIL", "test@test.com"},
+    {"GIT_COMMITTER_NAME", "Test User"},
+    {"GIT_COMMITTER_EMAIL", "test@test.com"}
+  ]
+
+  defp setup_repo do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "git_sparse_checkout_test_#{:erlang.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    cfg = Config.new(working_dir: tmp_dir, env: @env)
+    {:ok, :done} = Git.init(config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.name", set_value: "Test User", config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.email", set_value: "test@test.com", config: cfg)
+    {:ok, _} = Git.commit("initial", allow_empty: true, config: cfg)
+    {tmp_dir, cfg}
+  end
+
+  setup do
+    {tmp_dir, config} = setup_repo()
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+    %{tmp_dir: tmp_dir, config: config}
+  end
+
+  describe "Git.Commands.SparseCheckout args/1" do
+    test "builds args for list (default)" do
+      assert SparseCheckout.args(%SparseCheckout{}) == ["sparse-checkout", "list"]
+    end
+
+    test "builds args for init" do
+      assert SparseCheckout.args(%SparseCheckout{init: true}) == ["sparse-checkout", "init"]
+    end
+
+    test "builds args for init with cone mode" do
+      assert SparseCheckout.args(%SparseCheckout{init: true, cone: true}) ==
+               ["sparse-checkout", "init", "--cone"]
+    end
+
+    test "builds args for init with sparse_index" do
+      assert SparseCheckout.args(%SparseCheckout{init: true, sparse_index: true}) ==
+               ["sparse-checkout", "init", "--sparse-index"]
+    end
+
+    test "builds args for init with no_sparse_index" do
+      assert SparseCheckout.args(%SparseCheckout{init: true, no_sparse_index: true}) ==
+               ["sparse-checkout", "init", "--no-sparse-index"]
+    end
+
+    test "builds args for set with patterns" do
+      assert SparseCheckout.args(%SparseCheckout{set: ["src/", "docs/"]}) ==
+               ["sparse-checkout", "set", "src/", "docs/"]
+    end
+
+    test "builds args for set with cone mode" do
+      assert SparseCheckout.args(%SparseCheckout{set: ["src/"], cone: true}) ==
+               ["sparse-checkout", "set", "--cone", "src/"]
+    end
+
+    test "builds args for set with no_cone mode" do
+      assert SparseCheckout.args(%SparseCheckout{set: ["*.ex"], no_cone: true}) ==
+               ["sparse-checkout", "set", "--no-cone", "*.ex"]
+    end
+
+    test "builds args for add with patterns" do
+      assert SparseCheckout.args(%SparseCheckout{add: ["tests/"]}) ==
+               ["sparse-checkout", "add", "tests/"]
+    end
+
+    test "builds args for add with cone mode" do
+      assert SparseCheckout.args(%SparseCheckout{add: ["tests/"], cone: true}) ==
+               ["sparse-checkout", "add", "--cone", "tests/"]
+    end
+
+    test "builds args for disable" do
+      assert SparseCheckout.args(%SparseCheckout{disable: true}) ==
+               ["sparse-checkout", "disable"]
+    end
+
+    test "builds args for reapply" do
+      assert SparseCheckout.args(%SparseCheckout{reapply: true}) ==
+               ["sparse-checkout", "reapply"]
+    end
+
+    test "builds args for check_rules" do
+      assert SparseCheckout.args(%SparseCheckout{check_rules: true}) ==
+               ["sparse-checkout", "check-rules"]
+    end
+  end
+
+  describe "git sparse-checkout integration" do
+    test "init, set, list, and disable workflow", %{tmp_dir: tmp_dir, config: config} do
+      # Create files in different directories
+      src_dir = Path.join(tmp_dir, "src")
+      docs_dir = Path.join(tmp_dir, "docs")
+      tests_dir = Path.join(tmp_dir, "tests")
+      File.mkdir_p!(src_dir)
+      File.mkdir_p!(docs_dir)
+      File.mkdir_p!(tests_dir)
+      File.write!(Path.join(src_dir, "main.ex"), "defmodule Main do\nend\n")
+      File.write!(Path.join(docs_dir, "guide.md"), "# Guide\n")
+      File.write!(Path.join(tests_dir, "main_test.ex"), "defmodule MainTest do\nend\n")
+      {:ok, :done} = Git.add(all: true, config: config)
+      {:ok, _} = Git.commit("add project files", config: config)
+
+      # Init sparse-checkout with cone mode
+      assert {:ok, :done} = Git.sparse_checkout(init: true, cone: true, config: config)
+
+      # Set patterns to only include src directory
+      assert {:ok, :done} = Git.sparse_checkout(set: ["src"], cone: true, config: config)
+
+      # List patterns
+      assert {:ok, patterns} = Git.sparse_checkout(config: config)
+      assert is_list(patterns)
+      assert "src" in patterns
+
+      # Disable sparse-checkout
+      assert {:ok, :done} = Git.sparse_checkout(disable: true, config: config)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

8 new commands bringing the total to 47:

- **rev-list** -- list commit SHAs with filtering, counting, left-right divergence
- **merge-base** -- find common ancestors, ancestry checking
- **cherry** -- find commits not yet applied upstream, with `CherryEntry` struct
- **cat-file** -- inspect raw git objects (type, size, content, existence check)
- **check-ignore** -- debug gitignore rules with verbose pattern matching
- **notes** -- attach/read/remove/list metadata on commits
- **range-diff** -- compare two versions of a branch (pre/post rebase)
- **sparse-checkout** -- partial checkout management for monorepos

## Test plan

- [x] `mix format --check-formatted` passes
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix credo --strict` -- 0 issues
- [x] `mix test` -- 842 tests, 0 failures

Closes #40, #41, #42, #43, #44, #45, #46, #47