### PR TITLE
feat: add commit-tree plumbing wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ config = Git.Config.new(
 
 ## Commands
 
-64 git commands with full option support and parsed output.
+65 git commands with full option support and parsed output.
 
 ### Core (snapshotting, branching, sharing)
 
@@ -142,6 +142,7 @@ config = Git.Config.new(
 | Function | git command | Returns |
 |---|---|---|
 | `cat_file/2` | `git cat-file` | varies |
+| `commit_tree/1` | `git commit-tree` | `String.t()` |
 | `for_each_ref/1` | `git for-each-ref` | `String.t()` |
 | `hash_object/1` | `git hash-object` | `String.t()` |
 | `symbolic_ref/1` | `git symbolic-ref` | `String.t()` or `:done` |

--- a/lib/git.ex
+++ b/lib/git.ex
@@ -2020,4 +2020,37 @@ defmodule Git do
     command = struct!(Git.Commands.UpdateRef, rest)
     Git.Command.run(Git.Commands.UpdateRef, command, config)
   end
+
+  @doc """
+  Runs `git commit-tree` to build a commit object directly from a tree.
+
+  Plumbing command. Does not touch the index, working tree, or HEAD.
+  The new commit lives only as a loose object until referenced from a
+  ref via `update_ref/1`. Returns the new commit's SHA on success.
+
+  ## Options
+
+    * `:config` - a `Git.Config` struct (default: `Git.Config.new()`)
+    * `:tree` - the tree SHA to commit (required)
+    * `:parents` - list of parent commit SHAs (default: `[]`)
+    * `:message` - commit message, single string (`-m`)
+    * `:messages` - list of messages, each becomes a separate `-m`
+      (concatenated as paragraphs in the resulting commit message)
+    * `:sign` - `true` for `-S` (use the configured signing key) or a
+      string keyid for `-S<keyid>`
+    * `:no_gpg_sign` - `--no-gpg-sign` (overrides `commit.gpgSign` config)
+
+  ## Examples
+
+      Git.commit_tree(tree: tree_sha, message: "thread: open")
+      Git.commit_tree(tree: tree_sha, parents: [head], message: "next", sign: true)
+      Git.commit_tree(tree: tree_sha, parents: [a, b], message: "merge")
+
+  """
+  @spec commit_tree(keyword()) :: {:ok, String.t()} | {:error, term()}
+  def commit_tree(opts \\ []) do
+    {config, rest} = Keyword.pop(opts, :config, Config.new())
+    command = struct!(Git.Commands.CommitTree, rest)
+    Git.Command.run(Git.Commands.CommitTree, command, config)
+  end
 end

--- a/lib/git/commands/commit_tree.ex
+++ b/lib/git/commands/commit_tree.ex
@@ -1,0 +1,118 @@
+defmodule Git.Commands.CommitTree do
+  @moduledoc """
+  Implements the `Git.Command` behaviour for `git commit-tree`.
+
+  Builds a commit object directly from a tree object, with zero or
+  more parents, a message, and optional GPG signing. Returns the new
+  commit's SHA.
+
+  Unlike `git commit`, this is a plumbing command: it does not touch
+  the index, working tree, or HEAD. It is the building block for
+  free-floating commits, e.g. commits attached only to a non-branch
+  ref with no presence on any branch.
+  """
+
+  @behaviour Git.Command
+
+  @enforce_keys [:tree]
+
+  @type t :: %__MODULE__{
+          tree: String.t(),
+          parents: [String.t()],
+          message: String.t() | nil,
+          messages: [String.t()],
+          sign: boolean() | String.t(),
+          no_gpg_sign: boolean()
+        }
+
+  defstruct [
+    :tree,
+    parents: [],
+    message: nil,
+    messages: [],
+    sign: false,
+    no_gpg_sign: false
+  ]
+
+  @doc """
+  Returns the argument list for `git commit-tree`.
+
+  ## Examples
+
+      iex> Git.Commands.CommitTree.args(%Git.Commands.CommitTree{tree: "abc123", message: "init"})
+      ["commit-tree", "-m", "init", "abc123"]
+
+      iex> Git.Commands.CommitTree.args(%Git.Commands.CommitTree{tree: "abc123", parents: ["def456"], message: "next"})
+      ["commit-tree", "-p", "def456", "-m", "next", "abc123"]
+
+      iex> Git.Commands.CommitTree.args(%Git.Commands.CommitTree{tree: "abc123", parents: ["a", "b"], message: "merge"})
+      ["commit-tree", "-p", "a", "-p", "b", "-m", "merge", "abc123"]
+
+      iex> Git.Commands.CommitTree.args(%Git.Commands.CommitTree{tree: "abc123", message: "x", sign: true})
+      ["commit-tree", "-S", "-m", "x", "abc123"]
+
+      iex> Git.Commands.CommitTree.args(%Git.Commands.CommitTree{tree: "abc123", message: "x", sign: "ABCD1234"})
+      ["commit-tree", "-SABCD1234", "-m", "x", "abc123"]
+
+      iex> Git.Commands.CommitTree.args(%Git.Commands.CommitTree{tree: "abc123", message: "x", no_gpg_sign: true})
+      ["commit-tree", "--no-gpg-sign", "-m", "x", "abc123"]
+
+      iex> Git.Commands.CommitTree.args(%Git.Commands.CommitTree{tree: "abc123", messages: ["subject", "body"]})
+      ["commit-tree", "-m", "subject", "-m", "body", "abc123"]
+
+      iex> Git.Commands.CommitTree.args(%Git.Commands.CommitTree{tree: "abc123", message: "subject", messages: ["body"]})
+      ["commit-tree", "-m", "subject", "-m", "body", "abc123"]
+
+  """
+  @spec args(t()) :: [String.t()]
+  @impl true
+  def args(%__MODULE__{tree: tree} = command) when is_binary(tree) do
+    ["commit-tree"]
+    |> add_parents(command.parents)
+    |> add_sign(command.sign)
+    |> maybe_add_flag(command.no_gpg_sign, "--no-gpg-sign")
+    |> add_messages(command.message, command.messages)
+    |> Kernel.++([tree])
+  end
+
+  @doc """
+  Parses the output of `git commit-tree`.
+
+  On success (exit code 0), returns `{:ok, sha}` where sha is the
+  trimmed SHA of the new commit. On failure, returns
+  `{:error, {stdout, exit_code}}`.
+  """
+  @spec parse_output(String.t(), non_neg_integer()) ::
+          {:ok, String.t()} | {:error, {String.t(), non_neg_integer()}}
+  @impl true
+  def parse_output(stdout, 0), do: {:ok, String.trim(stdout)}
+  def parse_output(stdout, exit_code), do: {:error, {stdout, exit_code}}
+
+  defp add_parents(args, []), do: args
+
+  defp add_parents(args, parents) when is_list(parents) do
+    args ++ Enum.flat_map(parents, fn p -> ["-p", p] end)
+  end
+
+  defp add_sign(args, false), do: args
+  defp add_sign(args, true), do: args ++ ["-S"]
+  defp add_sign(args, keyid) when is_binary(keyid), do: args ++ ["-S" <> keyid]
+
+  defp add_messages(args, nil, []), do: args
+
+  defp add_messages(args, message, []) when is_binary(message) do
+    args ++ ["-m", message]
+  end
+
+  defp add_messages(args, nil, messages) when is_list(messages) do
+    args ++ Enum.flat_map(messages, fn m -> ["-m", m] end)
+  end
+
+  defp add_messages(args, message, messages)
+       when is_binary(message) and is_list(messages) do
+    args ++ ["-m", message] ++ Enum.flat_map(messages, fn m -> ["-m", m] end)
+  end
+
+  defp maybe_add_flag(args, true, flag), do: args ++ [flag]
+  defp maybe_add_flag(args, false, _flag), do: args
+end

--- a/test/git/commands/commit_tree_test.exs
+++ b/test/git/commands/commit_tree_test.exs
@@ -1,0 +1,176 @@
+defmodule Git.Commands.CommitTreeTest do
+  use ExUnit.Case, async: true
+
+  alias Git.Commands.CommitTree
+  alias Git.Config
+
+  defp setup_repo do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "git_commit_tree_test_#{:erlang.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    cfg = Config.new(working_dir: tmp_dir)
+    {:ok, :done} = Git.init(config: cfg)
+    {:ok, :done} = Git.git_config(set_key: "user.name", set_value: "Test User", config: cfg)
+
+    {:ok, :done} =
+      Git.git_config(set_key: "user.email", set_value: "test@test.com", config: cfg)
+
+    # Tests should not pick up an ambient commit.gpgSign that would force
+    # signing on every commit-tree call.
+    {:ok, :done} = Git.git_config(set_key: "commit.gpgSign", set_value: "false", config: cfg)
+    {tmp_dir, cfg}
+  end
+
+  defp write_tree(tmp_dir, filename, contents) do
+    File.write!(Path.join(tmp_dir, filename), contents)
+    {_, 0} = System.cmd("git", ["add", filename], cd: tmp_dir)
+    {sha, 0} = System.cmd("git", ["write-tree"], cd: tmp_dir)
+    String.trim(sha)
+  end
+
+  setup do
+    {tmp_dir, config} = setup_repo()
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+    %{tmp_dir: tmp_dir, config: config}
+  end
+
+  describe "args/1" do
+    test "minimal: tree and message" do
+      assert CommitTree.args(%CommitTree{tree: "abc123", message: "init"}) ==
+               ["commit-tree", "-m", "init", "abc123"]
+    end
+
+    test "with one parent" do
+      assert CommitTree.args(%CommitTree{tree: "abc123", parents: ["p1"], message: "x"}) ==
+               ["commit-tree", "-p", "p1", "-m", "x", "abc123"]
+    end
+
+    test "with multiple parents (merge commit)" do
+      assert CommitTree.args(%CommitTree{tree: "abc123", parents: ["p1", "p2"], message: "x"}) ==
+               ["commit-tree", "-p", "p1", "-p", "p2", "-m", "x", "abc123"]
+    end
+
+    test "with sign true" do
+      assert CommitTree.args(%CommitTree{tree: "abc123", message: "x", sign: true}) ==
+               ["commit-tree", "-S", "-m", "x", "abc123"]
+    end
+
+    test "with sign keyid" do
+      assert CommitTree.args(%CommitTree{tree: "abc123", message: "x", sign: "ABCD1234"}) ==
+               ["commit-tree", "-SABCD1234", "-m", "x", "abc123"]
+    end
+
+    test "with no_gpg_sign" do
+      assert CommitTree.args(%CommitTree{tree: "abc123", message: "x", no_gpg_sign: true}) ==
+               ["commit-tree", "--no-gpg-sign", "-m", "x", "abc123"]
+    end
+
+    test "with multiple messages" do
+      assert CommitTree.args(%CommitTree{tree: "abc123", messages: ["subject", "body"]}) ==
+               ["commit-tree", "-m", "subject", "-m", "body", "abc123"]
+    end
+
+    test "message and messages combine, message first" do
+      assert CommitTree.args(%CommitTree{
+               tree: "abc123",
+               message: "subject",
+               messages: ["body"]
+             }) ==
+               ["commit-tree", "-m", "subject", "-m", "body", "abc123"]
+    end
+
+    test "no message at all (would read from stdin if invoked, valid arg list)" do
+      assert CommitTree.args(%CommitTree{tree: "abc123"}) ==
+               ["commit-tree", "abc123"]
+    end
+  end
+
+  describe "commit_tree integration" do
+    test "creates a root commit (no parents)", %{tmp_dir: tmp_dir, config: config} do
+      tree = write_tree(tmp_dir, "a.txt", "hello")
+
+      {:ok, sha} = Git.commit_tree(tree: tree, message: "root", config: config)
+
+      assert is_binary(sha)
+      assert String.length(sha) == 40
+
+      {body, 0} = System.cmd("git", ["cat-file", "-p", sha], cd: tmp_dir)
+      assert body =~ "tree #{tree}"
+      refute body =~ "parent "
+      assert body =~ "root"
+    end
+
+    test "creates a commit with one parent", %{tmp_dir: tmp_dir, config: config} do
+      tree1 = write_tree(tmp_dir, "a.txt", "a")
+      {:ok, parent} = Git.commit_tree(tree: tree1, message: "root", config: config)
+
+      tree2 = write_tree(tmp_dir, "b.txt", "b")
+
+      {:ok, child} =
+        Git.commit_tree(tree: tree2, parents: [parent], message: "child", config: config)
+
+      {body, 0} = System.cmd("git", ["cat-file", "-p", child], cd: tmp_dir)
+      assert body =~ "tree #{tree2}"
+      assert body =~ "parent #{parent}"
+      assert body =~ "child"
+    end
+
+    test "creates a merge commit with multiple parents", %{tmp_dir: tmp_dir, config: config} do
+      tree = write_tree(tmp_dir, "x.txt", "x")
+      {:ok, p1} = Git.commit_tree(tree: tree, message: "p1", config: config)
+      {:ok, p2} = Git.commit_tree(tree: tree, message: "p2", config: config)
+
+      {:ok, merge} =
+        Git.commit_tree(tree: tree, parents: [p1, p2], message: "merge", config: config)
+
+      {body, 0} = System.cmd("git", ["cat-file", "-p", merge], cd: tmp_dir)
+      assert body =~ "parent #{p1}"
+      assert body =~ "parent #{p2}"
+    end
+
+    test "multiple messages produce a multi-paragraph commit", %{tmp_dir: tmp_dir, config: config} do
+      tree = write_tree(tmp_dir, "a.txt", "x")
+
+      {:ok, sha} =
+        Git.commit_tree(
+          tree: tree,
+          messages: ["subject", "body line"],
+          config: config
+        )
+
+      {body, 0} = System.cmd("git", ["cat-file", "-p", sha], cd: tmp_dir)
+      assert body =~ "subject"
+      assert body =~ "body line"
+    end
+
+    test "errors on a non-existent tree SHA", %{config: config} do
+      assert {:error, _} =
+               Git.commit_tree(
+                 tree: "0000000000000000000000000000000000000000",
+                 message: "x",
+                 config: config
+               )
+    end
+
+    test "no commit lands on any branch (free-floating object)", %{
+      tmp_dir: tmp_dir,
+      config: config
+    } do
+      tree = write_tree(tmp_dir, "a.txt", "x")
+      {:ok, sha} = Git.commit_tree(tree: tree, message: "floating", config: config)
+
+      # The new commit exists as an object...
+      {_body, 0} = System.cmd("git", ["cat-file", "-p", sha], cd: tmp_dir)
+
+      # ...but is not reachable from any branch.
+      {refs, 0} =
+        System.cmd("git", ["branch", "--contains", sha], cd: tmp_dir, stderr_to_stdout: true)
+
+      assert refs == "" or refs =~ ~r/error|no such commit/
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `Git.commit_tree/1` wrapping `git commit-tree`
- Build commit objects directly from a tree, with zero or more parents, message(s), and optional GPG signing
- Returns the new commit's SHA on success

`git commit-tree` is the building block for free-floating commits, commits attached only to a non-branch ref with no presence in the index, working tree, or HEAD. Pairs with `update-ref` to create or extend custom ref namespaces (notes, schemas, audit trails, workflow state) without disturbing main-branch history.

15 new tests: 9 args/1 cases (parents 0/1/many, sign true/keyid/no_gpg_sign, single and multi message) and 6 integration cases (root commit, single parent, merge, multi-paragraph message, bad-tree error, free-floating object verification).

## Test plan

- [x] mix format --check-formatted
- [x] mix credo --strict
- [x] mix test (1165 tests, 0 failures)
- [x] mix dialyzer (0 errors, 0 warnings)